### PR TITLE
fix: removing exception to avoid loop break

### DIFF
--- a/src/JUS.CLI/JUS/BatchCommands.cs
+++ b/src/JUS.CLI/JUS/BatchCommands.cs
@@ -22,8 +22,6 @@ using System.IO;
 using JUSToolkit.BatchConverters;
 using JUSToolkit.Containers;
 using JUSToolkit.Containers.Converters;
-using JUSToolkit.Graphics.Converters;
-using JUSToolkit.Utils;
 using Yarhl.FileFormat;
 using Yarhl.FileSystem;
 using Yarhl.IO;

--- a/src/JUS.Tool/BatchConverters/Alar2Png.cs
+++ b/src/JUS.Tool/BatchConverters/Alar2Png.cs
@@ -72,7 +72,7 @@ namespace JUSToolkit.BatchConverters
 
                     using var atm = GetAtm(cleanName, alarNode.Root.Children[0]);
                     if (atm is null) {
-                        Console.WriteLine("Missing map file for: " + cleanName);
+                        Console.WriteLine("Missing map file for: " + child.Name);
                         continue;
                     }
 
@@ -98,7 +98,7 @@ namespace JUSToolkit.BatchConverters
 
             if (atm is null)
             {
-                throw new FormatException("Atm doesn't exist: " + name + ".atm");
+                Console.WriteLine("Atm doesn't exist: " + name + ".atm");
             }
 
             return atm;


### PR DESCRIPTION
When the converter couldn't find the .atm file it threw an exception and it break the loop.