### PR TITLE
Exporting a dig with different maps

### DIFF
--- a/src/JUS.CLI/JUS/BatchCommands.cs
+++ b/src/JUS.CLI/JUS/BatchCommands.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
+using System.Collections.Generic;
 using System.IO;
 using JUSToolkit.BatchConverters;
 using JUSToolkit.Containers;
@@ -33,6 +34,13 @@ namespace JUSToolkit.CLI.JUS
     /// </summary>
     public static class BatchCommands
     {
+        private static Dictionary<string, int> demoImages = new Dictionary<string, int>() {
+            { "_03.dig", 0 },
+            { "_05.dig", 1 },
+            { "_07.dig", 2 },
+            { "_09.dig", 3 },
+        };
+
         /// <summary>
         /// Export PNG files from an Alar container.
         /// </summary>
@@ -46,12 +54,15 @@ namespace JUSToolkit.CLI.JUS
                 throw new FormatException("Invalid container file");
             }
 
+            _ = container == "demo.aar" ? originalAlar
+                    .TransformWith<Alar2Png, Dictionary<string, int>>(demoImages)
+                : originalAlar
+                .TransformWith<Alar2Png>();
+
             NodeContainerFormat result = originalAlar
-                .TransformWith<Alar2Png>()
                 .GetFormatAs<NodeContainerFormat>();
 
-            foreach (var image in result.Root.Children)
-            {
+            foreach (var image in result.Root.Children) {
                 image.Stream.WriteTo(Path.Combine(output, image.Name + ".png"));
             }
 

--- a/src/JUS.Tool/BatchConverters/Alar2Png.cs
+++ b/src/JUS.Tool/BatchConverters/Alar2Png.cs
@@ -18,15 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
+using System.Collections.Generic;
 using System.IO;
 using JUSToolkit.Containers;
 using JUSToolkit.Containers.Converters;
-using JUSToolkit.Graphics;
 using JUSToolkit.Graphics.Converters;
 using JUSToolkit.Utils;
-using Texim.Compressions.Nitro;
-using Texim.Formats;
-using Texim.Images;
 using Yarhl.FileFormat;
 using Yarhl.FileSystem;
 using Yarhl.IO;
@@ -37,8 +34,21 @@ namespace JUSToolkit.BatchConverters
     /// Converts a bunch of PNGs to and Alar3.
     /// </summary>
     public class Alar2Png :
+        IInitializer<Dictionary<string, int>>,
         IConverter<BinaryFormat, NodeContainerFormat>
     {
+        //NodeContainerFormat transformedFiles;
+        /// <summary>
+        /// Gets or sets the param to export the same image with multiple maps.
+        /// </summary>
+        public Dictionary<string, int> MultipleMaps { get; set; }
+
+        /// <inheritdoc/>
+        public void Initialize(Dictionary<string, int> maps)
+        {
+            MultipleMaps = maps;
+        }
+
         /// <summary>
         /// Converts an ALAR container into a NodeContainerFormat with PNGs inside.
         /// </summary>
@@ -54,37 +64,62 @@ namespace JUSToolkit.BatchConverters
             NodeContainerFormat alarNode = new NodeContainerFormat();
 
             // In the future we need to encapsulate this
-            if (alarVersion.Major == 3)
-            {
+            if (alarVersion.Major == 3) {
                 alarNode = (Alar3)ConvertFormat.With<Binary2Alar3>(alar);
-            }
-            else if (alarVersion.Major == 2)
-            {
+            } else if (alarVersion.Major == 2) {
                 alarNode = (Alar2)ConvertFormat.With<Binary2Alar2>(alar);
             }
 
-            // Iterate NCF
-            foreach (var child in Navigator.IterateNodes(alarNode.Root))
-            {
-                if (Path.GetExtension(child.Name) == ".dig")
-                {
+            // Iterate alar
+            foreach (var child in Navigator.IterateNodes(alarNode.Root)) {
+                if (Path.GetExtension(child.Name) == ".dig") {
                     var cleanName = Path.GetFileNameWithoutExtension(child.Name);
+                    var childClone = new Node(cleanName, new BinaryFormat(child.Stream));
 
+                    // Some containers (demo.aar) have a special type of .dig that needs
+                    // to be compressed with 2 extra maps (we get 3 images with just one .dig)
+                    if (MultipleMaps is not null && MultipleMaps.ContainsKey(child.Name.Substring(2))) // remove the manga name
+                    {
+                        string mangaName = child.Name.Substring(0, 2);
+                        // _n_00.atm
+                        using var atm_n = GetAtm(
+                            GetSpecialMapName(mangaName, "n", child.Name.Substring(2)),
+                            alarNode.Root.Children[0]);
+
+                        if (atm_n is null) {
+                            Console.WriteLine("Missing special n map file for: " + child.Name);
+                        }
+
+                        BinaryFormat stream_n = (BinaryFormat)childClone.GetFormatAs<BinaryFormat>().DeepClone();
+                        var image_n = GetPNG(new Node(cleanName+"n", stream_n), atm_n, cleanName + "_n_");
+                        if (image_n is not null) {
+                            transformedFiles.Root.Add(image_n);
+                        }
+
+                        // _m_00.atm
+                        using var atm_m = GetAtm(
+                            GetSpecialMapName(mangaName, "m", child.Name.Substring(2)), 
+                            alarNode.Root.Children[0]);
+
+                        if (atm_m is null) {
+                            Console.WriteLine("Missing special m map file for: " + child.Name);
+                        }
+
+                        BinaryFormat stream_m = (BinaryFormat)childClone.GetFormatAs<BinaryFormat>().DeepClone();
+                        var image_m = GetPNG(new Node(cleanName+"m", stream_m), atm_m, cleanName);
+                        if (image_m is not null) {
+                            transformedFiles.Root.Add(image_m);
+                        }
+                    }
+                    // Get Map with the same name
                     using var atm = GetAtm(cleanName, alarNode.Root.Children[0]);
                     if (atm is null) {
                         Console.WriteLine("Missing map file for: " + child.Name);
                         continue;
                     }
-
-                    // We transform the dig+atm (with compression)
-                    try {
-                        var image = new Node(cleanName, new BinaryFormat(child.Stream))
-                        .TransformWith<BinaryDig2Bitmap, Node>(atm);
+                    var image = GetPNG(childClone, atm, cleanName);
+                    if (image is not null) {
                         transformedFiles.Root.Add(image);
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine("Exception detected in file " + cleanName + ": " + ex);
                     }
                 }
             }
@@ -92,12 +127,31 @@ namespace JUSToolkit.BatchConverters
             return transformedFiles;
         }
 
+        /// <summary>
+        /// Gets the name of the special map. Example: "bb_n_00.atm".
+        /// </summary>
+        private string GetSpecialMapName(string mangaName, string type, string fileNumber)
+        {
+            return mangaName + "_" + type + "_0" +
+                MultipleMaps.GetValueOrDefault(fileNumber);
+        }
+
+        private Node GetPNG(Node pixels, Node atm, string cleanName)
+        {
+            Node image = null;
+            try {
+                image = pixels.TransformWith<BinaryDig2Bitmap, Node>(atm);
+            } catch (Exception ex) {
+                Console.WriteLine("Exception detected in file " + cleanName + ": " + ex);
+            }
+            return image;
+        }
+
         private Node GetAtm(string name, Node files)
         {
             var atm = Navigator.SearchNode(files, name + ".atm");
 
-            if (atm is null)
-            {
+            if (atm is null) {
                 Console.WriteLine("Atm doesn't exist: " + name + ".atm");
             }
 

--- a/src/JUS.Tool/BatchConverters/Alar2Png.cs
+++ b/src/JUS.Tool/BatchConverters/Alar2Png.cs
@@ -37,7 +37,6 @@ namespace JUSToolkit.BatchConverters
         IInitializer<Dictionary<string, int>>,
         IConverter<BinaryFormat, NodeContainerFormat>
     {
-        //NodeContainerFormat transformedFiles;
         /// <summary>
         /// Gets or sets the param to export the same image with multiple maps.
         /// </summary>
@@ -78,9 +77,11 @@ namespace JUSToolkit.BatchConverters
 
                     // Some containers (demo.aar) have a special type of .dig that needs
                     // to be compressed with 2 extra maps (we get 3 images with just one .dig)
-                    if (MultipleMaps is not null && MultipleMaps.ContainsKey(child.Name.Substring(2))) // remove the manga name
+                    // child.Name.Substring(2) removes the manga name
+                    if (MultipleMaps is not null && MultipleMaps.ContainsKey(child.Name.Substring(2)))
                     {
                         string mangaName = child.Name.Substring(0, 2);
+
                         // _n_00.atm
                         using var atm_n = GetAtm(
                             GetSpecialMapName(mangaName, "n", child.Name.Substring(2)),
@@ -91,14 +92,14 @@ namespace JUSToolkit.BatchConverters
                         }
 
                         BinaryFormat stream_n = (BinaryFormat)childClone.GetFormatAs<BinaryFormat>().DeepClone();
-                        var image_n = GetPNG(new Node(cleanName+"n", stream_n), atm_n, cleanName + "_n_");
+                        var image_n = GetPNG(new Node(cleanName + "n", stream_n), atm_n, cleanName + "_n_");
                         if (image_n is not null) {
                             transformedFiles.Root.Add(image_n);
                         }
 
                         // _m_00.atm
                         using var atm_m = GetAtm(
-                            GetSpecialMapName(mangaName, "m", child.Name.Substring(2)), 
+                            GetSpecialMapName(mangaName, "m", child.Name.Substring(2)),
                             alarNode.Root.Children[0]);
 
                         if (atm_m is null) {
@@ -106,17 +107,19 @@ namespace JUSToolkit.BatchConverters
                         }
 
                         BinaryFormat stream_m = (BinaryFormat)childClone.GetFormatAs<BinaryFormat>().DeepClone();
-                        var image_m = GetPNG(new Node(cleanName+"m", stream_m), atm_m, cleanName);
+                        var image_m = GetPNG(new Node(cleanName + "m", stream_m), atm_m, cleanName);
                         if (image_m is not null) {
                             transformedFiles.Root.Add(image_m);
                         }
                     }
+
                     // Get Map with the same name
                     using var atm = GetAtm(cleanName, alarNode.Root.Children[0]);
                     if (atm is null) {
                         Console.WriteLine("Missing map file for: " + child.Name);
                         continue;
                     }
+
                     var image = GetPNG(childClone, atm, cleanName);
                     if (image is not null) {
                         transformedFiles.Root.Add(image);
@@ -144,6 +147,7 @@ namespace JUSToolkit.BatchConverters
             } catch (Exception ex) {
                 Console.WriteLine("Exception detected in file " + cleanName + ": " + ex);
             }
+
             return image;
         }
 

--- a/src/JUS.Tool/BatchConverters/Alar2Png.cs
+++ b/src/JUS.Tool/BatchConverters/Alar2Png.cs
@@ -92,7 +92,7 @@ namespace JUSToolkit.BatchConverters
                         }
 
                         BinaryFormat stream_n = (BinaryFormat)childClone.GetFormatAs<BinaryFormat>().DeepClone();
-                        var image_n = GetPNG(new Node(cleanName + "n", stream_n), atm_n, cleanName + "_n_");
+                        var image_n = GetPNG(new Node(Path.GetFileNameWithoutExtension(atm_n.Name), stream_n), atm_n, cleanName + "_n_");
                         if (image_n is not null) {
                             transformedFiles.Root.Add(image_n);
                         }
@@ -107,7 +107,7 @@ namespace JUSToolkit.BatchConverters
                         }
 
                         BinaryFormat stream_m = (BinaryFormat)childClone.GetFormatAs<BinaryFormat>().DeepClone();
-                        var image_m = GetPNG(new Node(cleanName + "m", stream_m), atm_m, cleanName);
+                        var image_m = GetPNG(new Node(Path.GetFileNameWithoutExtension(atm_m.Name), stream_m), atm_m, cleanName);
                         if (image_m is not null) {
                             transformedFiles.Root.Add(image_m);
                         }

--- a/src/JUS.Tool/Graphics/Converters/BinaryDig2Bitmap.cs
+++ b/src/JUS.Tool/Graphics/Converters/BinaryDig2Bitmap.cs
@@ -55,6 +55,7 @@ namespace JUSToolkit.Graphics.Converters
             if (source is null) {
                 throw new ArgumentNullException(nameof(source));
             }
+
             source.Stream.Position = 0;
 
             var pixelsPaletteNode = new Node("dig", source)

--- a/src/JUS.Tool/Graphics/Converters/BinaryDig2Bitmap.cs
+++ b/src/JUS.Tool/Graphics/Converters/BinaryDig2Bitmap.cs
@@ -55,6 +55,7 @@ namespace JUSToolkit.Graphics.Converters
             if (source is null) {
                 throw new ArgumentNullException(nameof(source));
             }
+            source.Stream.Position = 0;
 
             var pixelsPaletteNode = new Node("dig", source)
                 .TransformWith<LzssDecompression>()


### PR DESCRIPTION
In the demo.aar container we have several .dig files that need to be exported with 3 maps. This PR allows us to do so.

As right now the only container using this is demo.aar, I've hardcoded the equivalences in a Dictionary in BatchCommands.cs, but we should encapsulate that into an .yml maybe.