### PR TITLE
Fix/alar2 import

### DIFF
--- a/src/JUS.CLI/JUS/ContainerCommands.cs
+++ b/src/JUS.CLI/JUS/ContainerCommands.cs
@@ -139,9 +139,11 @@ namespace JUSToolkit.CLI.JUS
 
             var originalIsCompressed = CompressionUtils.IsCompressed(originalAlar);
 
-            var alarVersion = Identifier.GetAlarVersion(originalAlar.Stream);
+            if (originalIsCompressed) {
+                originalAlar.TransformWith<LzssDecompression>();
+            }
 
-            originalAlar.TransformWith<LzssDecompression>();
+            var alarVersion = Identifier.GetAlarVersion(originalAlar.Stream);
 
             BinaryFormat binary = new BinaryFormat();
 

--- a/src/JUS.Tests/Resources/.gitignore
+++ b/src/JUS.Tests/Resources/.gitignore
@@ -2,5 +2,6 @@
 *.dig
 *.dsig
 *.atm
+*.amt
 *.aar
 *.bin

--- a/src/JUS.Tests/Resources/Containers/alar2.txt
+++ b/src/JUS.Tests/Resources/Containers/alar2.txt
@@ -1,1 +1,2 @@
 deck_obj.yml,deck_obj.aar
+start.yml,start.aar

--- a/src/JUS.Tests/Resources/Containers/alar2insertion.txt
+++ b/src/JUS.Tests/Resources/Containers/alar2insertion.txt
@@ -1,0 +1,1 @@
+start.aar,alar2insertion

--- a/src/JUS.Tests/Resources/Containers/start.yml
+++ b/src/JUS.Tests/Resources/Containers/start.yml
@@ -1,0 +1,9 @@
+name: start.aar
+format_type: JUSToolkit.Containers.Alar2
+tags:
+check_children: true
+children:
+  - name: start.dtx
+    format_type: JUSToolkit.Containers.Alar2File
+  - name: start.amt
+    format_type: JUSToolkit.Containers.Alar2File

--- a/src/JUS.Tool/Containers/ALAR2File.cs
+++ b/src/JUS.Tool/Containers/ALAR2File.cs
@@ -6,16 +6,19 @@ namespace JUSToolkit.Containers
     /// <summary>
     /// Single file of an Alar2 Container.
     /// </summary>
-    public class Alar2File : BinaryFormat
+    public class Alar2File : IBinary
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Alar2File"/> class passing a DataStream.
         /// </summary>
         /// <param name="fileStream">DataStream.</param>
         public Alar2File(DataStream fileStream)
-            : base(fileStream)
         {
+            Stream = fileStream;
         }
+
+        /// <inheritdoc/>
+        public DataStream Stream { get; private set; }
 
         /// <summary>
         /// Gets or sets the internal game identifier of the file.
@@ -47,5 +50,15 @@ namespace JUSToolkit.Containers
         /// </summary>
         /// <remarks>If the container has 2 files, FileNum would be 1 or 2.</remarks>
         public int FileNum { get; set; }
+
+        /// <summary>
+        /// We replace the Alar2File Stream and the Size.
+        /// </summary>
+        /// <param name="stream">New DataStream.</param>
+        public void ReplaceStream(DataStream stream)
+        {
+            Stream = new DataStream(stream);
+            Size = (uint)stream.Length;
+        }
     }
 }

--- a/src/JUS.Tool/Containers/ALAR3.cs
+++ b/src/JUS.Tool/Containers/ALAR3.cs
@@ -22,7 +22,7 @@ namespace JUSToolkit.Containers
         public static readonly Version[] SupportedVersions = new Version[] { new Version(3, 5), new Version(3, 69) };
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Alar3" /> class with an empty list of <see cref="Alar3File" />.
+        /// Initializes a new instance of the <see cref="Alar3" /> class with an empty array of FileInfoPointers.
         /// </summary>
         /// <param name="numFiles">How many files are we storing.</param>
         public Alar3(uint numFiles)

--- a/src/JUS.Tool/Containers/ALAR3File.cs
+++ b/src/JUS.Tool/Containers/ALAR3File.cs
@@ -25,11 +25,6 @@ namespace JUSToolkit.Containers
         public ushort FileID { get; set; }
 
         /// <summary>
-        /// Gets or sets the Unknown.
-        /// </summary>
-        public ushort Unknown { get; set; }
-
-        /// <summary>
         /// Gets or sets the absolute pointer of the File.
         /// </summary>
         public uint Offset { get; set; }
@@ -38,6 +33,11 @@ namespace JUSToolkit.Containers
         /// Gets or sets the size of the File.
         /// </summary>
         public uint Size { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Unknown.
+        /// </summary>
+        public ushort Unknown { get; set; }
 
         /// <summary>
         /// Gets or sets the Unknown2.

--- a/src/JUS.Tool/Containers/Converters/Alar2ToBinary.cs
+++ b/src/JUS.Tool/Containers/Converters/Alar2ToBinary.cs
@@ -83,7 +83,9 @@ namespace JUSToolkit.Containers.Converters
                 if (!alarFile.IsContainer) {
                     writer.WriteTimes(0, 2);
                     writer.Write(alarFile.Name);
-                    writer.WriteTimes(0, 19); // we already have the null byte
+                    // Tenemos que pintar ceros hasta el offset del puntero - 02 (que hay un unknown)
+                    int times = 32 - alarFile.Name.Length - 1; // 1 null byte
+                    writer.WriteTimes(0, times);
 
                     Alar2File alarChild = alarFile.GetFormatAs<Alar2File>();
 

--- a/src/JUS.Tool/Containers/Converters/Alar2ToBinary.cs
+++ b/src/JUS.Tool/Containers/Converters/Alar2ToBinary.cs
@@ -83,6 +83,7 @@ namespace JUSToolkit.Containers.Converters
                 if (!alarFile.IsContainer) {
                     writer.WriteTimes(0, 2);
                     writer.Write(alarFile.Name);
+
                     // Tenemos que pintar ceros hasta el offset del puntero - 02 (que hay un unknown)
                     int times = 32 - alarFile.Name.Length - 1; // 1 null byte
                     writer.WriteTimes(0, times);

--- a/src/JUS.Tool/Containers/Converters/Binary2Alar2.cs
+++ b/src/JUS.Tool/Containers/Converters/Binary2Alar2.cs
@@ -64,7 +64,7 @@ namespace JUSToolkit.Containers.Converters
                     Size = size,
                     Unknown = unknown,
                     FileNum = i + 1,
-            };
+                };
 
                 input.Stream.RunInPosition(() => alarFile.Unknown2 = reader.ReadUInt16(), offset - 2);
                 input.Stream.RunInPosition(() => ReadFileInfo(alarFile), name_offset + 2);
@@ -87,10 +87,7 @@ namespace JUSToolkit.Containers.Converters
                 throw new FormatException($"Unsupported version: {version:X}");
             }
 
-            alar = new Alar2 {
-                NumFiles = reader.ReadUInt16(),
-                IDs = new byte[8],
-            };
+            alar = new Alar2(reader.ReadUInt16());
 
             for (int i = 0; i < 8; i++) {
                 alar.IDs[i] = reader.ReadByte();

--- a/src/JUS.Tool/Graphics/Converters/LzssUtils.cs
+++ b/src/JUS.Tool/Graphics/Converters/LzssUtils.cs
@@ -30,8 +30,8 @@ namespace JUSToolkit.Graphics.Converters
     /// </summary>
     public static class LzssUtils
     {
-        private static string programExe = System.IO.Path.GetFullPath(@"..\..\..\..\..\") + @"\lib\NDS_Compressors_CUE\lzss.exe";
-        private static string programUnix = System.IO.Path.GetFullPath(@"../../../../../") + "/lib/NDS_Compressors_CUE/lzss";
+        private static readonly string programExe = System.IO.Path.GetFullPath(@"..\..\..\..\..\") + @"\lib\NDS_Compressors_CUE\lzss.exe";
+        private static readonly string programUnix = System.IO.Path.GetFullPath(@"../../../../../") + "lib/NDS_Compressors_CUE/lzss";
 
         /// <summary>
         /// Calls the external CUE's lzss library. It executes the unix binary.
@@ -61,8 +61,9 @@ namespace JUSToolkit.Graphics.Converters
         /// </summary>
         /// <param name="program">The program path.</param>
         /// <param name="arguments">The arguments for the program.</param>
-        private static void ExecuteExternalProcess(string program, string arguments) {
-            Process process = new Process();
+        private static void ExecuteExternalProcess(string program, string arguments)
+        {
+            var process = new Process();
             process.StartInfo.FileName = program;
             process.StartInfo.Arguments = arguments;
             process.StartInfo.UseShellExecute = false;

--- a/src/JUS.Tool/Graphics/Converters/LzssUtils.cs
+++ b/src/JUS.Tool/Graphics/Converters/LzssUtils.cs
@@ -30,8 +30,8 @@ namespace JUSToolkit.Graphics.Converters
     /// </summary>
     public static class LzssUtils
     {
-        private static readonly string programExe = System.IO.Path.GetFullPath(@"..\..\..\..\..\") + @"\lib\NDS_Compressors_CUE\lzss.exe";
-        private static readonly string programUnix = System.IO.Path.GetFullPath(@"../../../../../") + "lib/NDS_Compressors_CUE/lzss";
+        private static readonly string ProgramExe = System.IO.Path.GetFullPath(@"..\..\..\..\..\") + @"\lib\NDS_Compressors_CUE\lzss.exe";
+        private static readonly string ProgramUnix = System.IO.Path.GetFullPath(@"../../../../../") + "lib/NDS_Compressors_CUE/lzss";
 
         /// <summary>
         /// Calls the external CUE's lzss library. It executes the unix binary.
@@ -46,7 +46,7 @@ namespace JUSToolkit.Graphics.Converters
             string tempFile = Path.GetRandomFileName();
             input.WriteTo(tempFile);
 
-            string program = Environment.OSVersion.Platform == PlatformID.Win32NT ? programExe : programUnix;
+            string program = Environment.OSVersion.Platform == PlatformID.Win32NT ? ProgramExe : ProgramUnix;
             string arguments = mode + " " + tempFile;
             ExecuteExternalProcess(program, arguments);
 


### PR DESCRIPTION
### Description

Alar2 importer was not working correctly because we were always adding 19 zeros after writing the name:
![image](https://github.com/priverop/JUSToolkit/assets/1587633/1848ac20-54f6-413e-8dda-815c1234e89c)

![image](https://github.com/priverop/JUSToolkit/assets/1587633/baa5f867-28b9-46c7-835c-41b56df38cfd)

This is wrong because it depends on the size of the string.

### Example

<img width="557" alt="image" src="https://github.com/priverop/JUSToolkit/assets/1587633/cacf652c-2a0e-4ed0-87b5-aa754388621e">

Here we have a 18bytes zero string. 

### Solution

The string plus the zeros should take 32bytes total, so we are doing:

`int times = 32 - alarFile.Name.Length - 1;`

32 bytes minus the length (and its ending null byte).


+ I'm adding tests.