### PR TITLE
feat: batch export dt3 improved

### DIFF
--- a/src/JUS.Tool/BatchConverters/Alar2Png.cs
+++ b/src/JUS.Tool/BatchConverters/Alar2Png.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using JUSToolkit.Containers;
 using JUSToolkit.Containers.Converters;
 using JUSToolkit.Graphics.Converters;
@@ -162,7 +163,7 @@ namespace JUSToolkit.BatchConverters
 
         private Node GetAtm(string name, Node files)
         {
-            Node atm = Navigator.SearchNode(files, name + ".atm");
+            Node atm = Navigator.IterateNodes(files).First(n => n.Name == name + ".atm");
 
             if (atm is null) {
                 Console.WriteLine("Atm doesn't exist: " + name + ".atm");


### PR DESCRIPTION
### Description

Added nested export method for alar -> dtx3 -> png. So we can export everything at once.

Plus, fixed Alar2Png Node search.