### PR TITLE
feat: export segments

### DIFF
--- a/src/JUS.CLI/JUS/CommandLine.cs
+++ b/src/JUS.CLI/JUS/CommandLine.cs
@@ -121,17 +121,17 @@ namespace JUSToolkit.CLI.JUS
             };
             mergeDig.Handler = CommandHandler.Create<string[], bool, string, string[], string>(DigCommands.MergeDig);
 
-            var exportYamlDtx3 = new Command("export-yaml-dtx3", "Export the sprite metadata") {
+            var exportDtx3Segments = new Command("export-dtx3-segments", "Export the segments and yaml") {
                 new Option<string>("--dtx", "the input file.dtx", ArgumentArity.ExactlyOne),
                 new Option<string>("--output", "the output folder", ArgumentArity.ExactlyOne),
             };
-            exportYamlDtx3.Handler = CommandHandler.Create<string, string>(DtxCommands.ExportYamlDtx3);
+            exportDtx3Segments.Handler = CommandHandler.Create<string, string>(DtxCommands.ExportDtx3Segments);
 
             return new Command("graphics", "Import/Export graphic files") {
                 exportKomas,
                 exportDtx3,
                 exportDtx3TxImage,
-                exportYamlDtx3,
+                exportDtx3Segments,
                 exportDtx4,
                 importDtx3,
                 importDtx3Tx,

--- a/src/JUS.CLI/JUS/ContainerCommands.cs
+++ b/src/JUS.CLI/JUS/ContainerCommands.cs
@@ -137,6 +137,7 @@ namespace JUSToolkit.CLI.JUS
             Console.WriteLine("Importing Alar");
             Console.WriteLine("Container: " + container);
             Console.WriteLine("Input files from: " + input);
+            Console.WriteLine();
 
             PathValidator.ValidateFile(container);
             PathValidator.ValidateDirectory(input);

--- a/src/JUS.CLI/JUS/Graphics/DtxCommands.cs
+++ b/src/JUS.CLI/JUS/Graphics/DtxCommands.cs
@@ -32,6 +32,7 @@ using Texim.Pixels;
 using Texim.Processing;
 using Texim.Sprites;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.Converters;
 using YamlDotNet.Serialization.NamingConventions;
 using Yarhl.FileSystem;
 using Yarhl.IO;
@@ -447,26 +448,30 @@ namespace JUSToolkit.CLI.JUS
         }
 
         /// <summary>
-        /// Export a the segments info from a .dtx file  a YAML metadata file.
+        /// Export the segments and the YAML from a .dtx file.
         /// </summary>
         /// <param name="dtx">The .dtx file.</param>
         /// <param name="output">The output folder.</param>
         /// <exception cref="FormatException"><paramref name="dtx"/> file doesn't have a valid format.</exception>
-        public static void ExportYamlDtx3(string dtx, string output)
+        public static void ExportDtx3Segments(string dtx, string output)
         {
-            Console.WriteLine("Exporting Dtx3 file with YAML metadata");
+            Console.WriteLine("Exporting Segments and YAML from Dtx3 file");
             Console.WriteLine("DTX: " + dtx);
 
             PathValidator.ValidateFile(dtx);
 
+            var converter = new BinaryToDtx3(output);
+
             // Sprites + pixels + palette
             using Node dtx3 = NodeFactory.FromFile(dtx, FileOpenMode.Read)
                 .TransformWith<LzssDecompression>()
-                .TransformWith<BinaryToDtx3>();
+                .TransformWith(converter);
 
             BinaryFormat segmentInfo = dtx3.Children["yaml"].GetFormatAs<BinaryFormat>();
 
             segmentInfo.Stream.WriteTo(Path.Combine(output, Path.GetFileName(dtx)) + ".yaml");
+
+            Console.WriteLine("Done!");
         }
 
         private static List<SpriteDummy> GetYamlInfo(string path)

--- a/src/JUS.CLI/JUS/Graphics/DtxCommands.cs
+++ b/src/JUS.CLI/JUS/Graphics/DtxCommands.cs
@@ -65,6 +65,8 @@ namespace JUSToolkit.CLI.JUS
             foreach (Node nodeSprite in dtx3.Children) {
                 nodeSprite.Stream.WriteTo(Path.Combine(output, $"{nodeSprite.Name}.png"));
             }
+
+            Console.WriteLine("Done!");
         }
 
         /// <summary>
@@ -98,7 +100,7 @@ namespace JUSToolkit.CLI.JUS
 
             image.Stream.WriteTo(Path.Combine(output, Path.GetFileNameWithoutExtension(dtx) + "_tx.png"));
 
-            Console.WriteLine("Done");
+            Console.WriteLine("Done!");
         }
 
         /// <summary>

--- a/src/JUS.Tool/Containers/ALAR2.cs
+++ b/src/JUS.Tool/Containers/ALAR2.cs
@@ -58,7 +58,7 @@ namespace JUSToolkit.Containers
         {
             foreach (Node nNew in Navigator.IterateNodes(filesToInsert.Root)) {
                 if (!nNew.IsContainer) {
-                    Console.WriteLine("Inserting " + nNew.Name);
+                    Console.WriteLine("Searching for " + nNew.Name + "...:");
                     InsertModification(nNew);
                 }
             }
@@ -74,6 +74,7 @@ namespace JUSToolkit.Containers
             uint nextFileOffset = 0;
             bool replaced = false;
 
+            Console.ForegroundColor = ConsoleColor.Green;
             foreach (Node nOld in Navigator.IterateNodes(Root)) {
                 if (!nOld.IsContainer) {
                     Alar2File alarFileOld = nOld.GetFormatAs<Alar2File>();
@@ -84,7 +85,7 @@ namespace JUSToolkit.Containers
                     }
 
                     if (parent == null && nOld.Name == nNew.Name) {
-                        Console.WriteLine("Replacing: " + nNew.Name);
+                        Console.WriteLine("✅Replacing: " + nNew.Name);
                         alarFileOld.ReplaceStream(nNew.Stream);
                         replaced = true;
                     }
@@ -98,9 +99,9 @@ namespace JUSToolkit.Containers
                     nextFileOffset = alarFileOld.Offset + alarFileOld.Size;
                 }
             }
-
+            Console.ResetColor();
             if (!replaced) {
-                Console.WriteLine($"{nNew.Name} node not found in the container");
+                Console.WriteLine($"❌ {nNew.Name} node not found in the container");
             }
         }
     }

--- a/src/JUS.Tool/Containers/ALAR3.cs
+++ b/src/JUS.Tool/Containers/ALAR3.cs
@@ -69,7 +69,7 @@ namespace JUSToolkit.Containers
         {
             foreach (Node nNew in Navigator.IterateNodes(filesToInsert.Root)) {
                 if (!nNew.IsContainer) {
-                    Console.WriteLine("Inserting " + nNew.Name);
+                    Console.WriteLine("Searching for " + nNew.Name + "...:");
                     InsertModification(nNew);
                 }
             }
@@ -85,7 +85,7 @@ namespace JUSToolkit.Containers
         {
             uint nextFileOffset = 0;
             bool replaced = false;
-
+            Console.ForegroundColor = ConsoleColor.Green;
             foreach (Node nOld in Navigator.IterateNodes(Root)) {
                 if (!nOld.IsContainer) {
                     Alar3File alarFileOld = nOld.GetFormatAs<Alar3File>();
@@ -96,7 +96,7 @@ namespace JUSToolkit.Containers
                     }
 
                     if (parent == null && nOld.Name == nNew.Name) {
-                        Console.WriteLine("Replacing: " + nNew.Name);
+                        Console.WriteLine("✅ Replacing: " + nNew.Name);
                         alarFileOld.ReplaceStream(nNew.Stream);
                         replaced = true;
                     }
@@ -110,9 +110,9 @@ namespace JUSToolkit.Containers
                     nextFileOffset = alarFileOld.Offset + alarFileOld.Size;
                 }
             }
-
+            Console.ResetColor();
             if (!replaced) {
-                Console.WriteLine($"{nNew.Name} node not found in the container");
+                Console.WriteLine($"❌ {nNew.Name} node not found in the container");
             }
         }
     }

--- a/src/JUS.Tool/Graphics/Converters/BinaryToDtx3.cs
+++ b/src/JUS.Tool/Graphics/Converters/BinaryToDtx3.cs
@@ -138,7 +138,7 @@ namespace JUS.Tool.Graphics.Converters
                 sprite.Segments.Add(segment);
 
                 if (SegmentsOutputPath != null) {
-                    ImageSegment2IndexedImage segment2Indexed = new ImageSegment2IndexedImage(new ImageSegment2IndexedImageParams {
+                    var segment2Indexed = new ImageSegment2IndexedImage(new ImageSegment2IndexedImageParams {
                         FullImage = fullImage,
                         IsTiled = true,
                     });

--- a/src/JUS.Tool/Graphics/Converters/BinaryToDtx3.cs
+++ b/src/JUS.Tool/Graphics/Converters/BinaryToDtx3.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using JUSToolkit.Graphics;
 using JUSToolkit.Graphics.Converters;
+using Texim.Formats;
 using Texim.Pixels;
 using Texim.Sprites;
 using YamlDotNet.Serialization;
@@ -23,6 +24,25 @@ namespace JUS.Tool.Graphics.Converters
         private const int PointerOffset = 0x0A;
         private readonly Binary2Dig digConverter = new();
         private List<SpriteDummy> spriteCollection;
+
+        private string SegmentsOutputPath;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinaryToDtx3"/> class.
+        /// </summary>
+        /// <param name="segmentsOutputPath">Path to export segments.</param>
+        public BinaryToDtx3(string segmentsOutputPath)
+        {
+            SegmentsOutputPath = segmentsOutputPath;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BinaryToDtx3"/> class.
+        /// </summary>
+        public BinaryToDtx3()
+        {
+            SegmentsOutputPath = null;
+        }
 
         /// <summary>
         /// Converts a <see cref="BinaryFormat"/> (file) to a dtx3 <see cref="NodeContainerFormat"/>.
@@ -64,7 +84,7 @@ namespace JUS.Tool.Graphics.Converters
                         sprites.Root.Add(new Node($"sp_{i:00}", ReadSprite(reader)));
                         break;
                     case DigSwizzling.Linear:
-                        sprites.Root.Add(new Node($"tx_{i:00}", ReadTexture(reader, image)));
+                        sprites.Root.Add(new Node($"tx_{i:00}", ReadTexture(reader, image, i)));
                         break;
                     default:
                         throw new FormatException("Invalid swizzling");
@@ -128,7 +148,7 @@ namespace JUS.Tool.Graphics.Converters
 
         // These false sprites (we call them Textures) have a Linear image, so we can't
         // use the Texim Sprite system. That's why we compose regular images.
-        private Dig ReadTexture(DataReader reader, Dig fullImage)
+        private Dig ReadTexture(DataReader reader, Dig fullImage, int index)
         {
             var frame = new Dig(fullImage) {
                 Pixels = new IndexedPixel[256 * 256],
@@ -139,7 +159,7 @@ namespace JUS.Tool.Graphics.Converters
             int spriteOffset = reader.ReadUInt16() + PointerOffset;
             reader.Stream.PushToPosition(spriteOffset);
             ushort numSegments = reader.ReadUInt16();
-            SpriteDummy sprite = new SpriteDummy();
+            var sprite = new SpriteDummy();
 
             for (int i = 0; i < numSegments; i++) {
                 ushort tileIndex = reader.ReadUInt16();
@@ -151,6 +171,17 @@ namespace JUS.Tool.Graphics.Converters
                 (bool hFlip, bool vFlip) = GetFlip(shape >> 4);
 
                 var segment = new Dig(fullImage, width, height, tileIndex);
+
+                if (SegmentsOutputPath != null) {
+
+                    var indexedImageParams = new IndexedImageBitmapParams {
+                        Palettes = segment,
+                    };
+
+                    BinaryFormat a = new IndexedImage2Bitmap(indexedImageParams).Convert(segment);
+                    a.Stream.WriteTo($"{SegmentsOutputPath}/segments/{index}_segment{i}.png");
+
+                }
 
                 frame.PasteImage(segment, xPos, yPos, hFlip, vFlip, paletteIndex);
 

--- a/src/JUS.Tool/Graphics/Converters/BinaryToDtx3.cs
+++ b/src/JUS.Tool/Graphics/Converters/BinaryToDtx3.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using JUSToolkit.Graphics;
 using JUSToolkit.Graphics.Converters;
 using Texim.Formats;
+using Texim.Images;
 using Texim.Pixels;
 using Texim.Sprites;
 using YamlDotNet.Serialization;
@@ -81,7 +82,7 @@ namespace JUS.Tool.Graphics.Converters
             for (int i = 0; i < numSprites; i++) {
                 switch (image.Swizzling) {
                     case DigSwizzling.Tiled:
-                        sprites.Root.Add(new Node($"sp_{i:00}", ReadSprite(reader)));
+                        sprites.Root.Add(new Node($"sp_{i:00}", ReadSprite(reader, image, i)));
                         break;
                     case DigSwizzling.Linear:
                         sprites.Root.Add(new Node($"tx_{i:00}", ReadTexture(reader, image, i)));
@@ -106,7 +107,7 @@ namespace JUS.Tool.Graphics.Converters
             return container;
         }
 
-        private Sprite ReadSprite(DataReader reader)
+        private Sprite ReadSprite(DataReader reader, Dig fullImage, int index)
         {
             int spriteOffset = reader.ReadUInt16() + PointerOffset;
             reader.Stream.PushToPosition(spriteOffset);
@@ -135,6 +136,18 @@ namespace JUS.Tool.Graphics.Converters
                     Layer = numSegments - i,
                 };
                 sprite.Segments.Add(segment);
+
+                if (SegmentsOutputPath != null) {
+                    ImageSegment2IndexedImage segment2Indexed = new ImageSegment2IndexedImage(new ImageSegment2IndexedImageParams {
+                        FullImage = fullImage,
+                        IsTiled = true,
+                    });
+
+                    FullImage segmentImage = segment2Indexed.Convert(segment).CreateFullImage(fullImage, false);
+
+                    BinaryFormat pngSegment = new FullImage2Bitmap().Convert(segmentImage);
+                    pngSegment.Stream.WriteTo($"{SegmentsOutputPath}/segments/{index}_segment{i}.png");
+                }
             }
 
             sprite.Width = 256;
@@ -173,14 +186,12 @@ namespace JUS.Tool.Graphics.Converters
                 var segment = new Dig(fullImage, width, height, tileIndex);
 
                 if (SegmentsOutputPath != null) {
-
                     var indexedImageParams = new IndexedImageBitmapParams {
                         Palettes = segment,
                     };
 
                     BinaryFormat a = new IndexedImage2Bitmap(indexedImageParams).Convert(segment);
                     a.Stream.WriteTo($"{SegmentsOutputPath}/segments/{index}_segment{i}.png");
-
                 }
 
                 frame.PasteImage(segment, xPos, yPos, hFlip, vFlip, paletteIndex);
@@ -211,18 +222,18 @@ namespace JUS.Tool.Graphics.Converters
             int[] sizes = new int[4] { 8, 16, 32, 64 };
 
             return shape switch {
-                0x00 => (sizes[0], sizes[0]),   // 1x1
-                0x01 => (sizes[1], sizes[1]),   // 2x2
-                0x02 => (sizes[2], sizes[2]),   // 4x4
-                0x03 => (sizes[3], sizes[3]),   // 8x8
-                0x04 => (sizes[1], sizes[0]),   // 2x1
-                0x05 => (sizes[2], sizes[0]),   // 4x1
-                0x06 => (sizes[2], sizes[1]),   // 4x2
-                0x07 => (sizes[3], sizes[2]),   // 8x4
-                0x08 => (sizes[0], sizes[1]),   // 1x2
-                0x09 => (sizes[0], sizes[2]),   // 1x4
-                0x0A => (sizes[1], sizes[2]),   // 2x4
-                0x0B => (sizes[2], sizes[3]),   // 4x8
+                0x00 => (sizes[0], sizes[0]),   // 1x1 tiles = 8x8 pixels
+                0x01 => (sizes[1], sizes[1]),   // 2x2 tiles = 16x16 pixels
+                0x02 => (sizes[2], sizes[2]),   // 4x4 tiles = 32x32 pixels
+                0x03 => (sizes[3], sizes[3]),   // 8x8 tiles = 64x64 pixels
+                0x04 => (sizes[1], sizes[0]),   // 2x1 tiles = 16x8 pixels
+                0x05 => (sizes[2], sizes[0]),   // 4x1 tiles = 32x8 pixels
+                0x06 => (sizes[2], sizes[1]),   // 4x2 tiles = 32x16 pixels
+                0x07 => (sizes[3], sizes[2]),   // 8x4 tiles = 64x32 pixels
+                0x08 => (sizes[0], sizes[1]),   // 1x2 tiles = 8x16 pixels
+                0x09 => (sizes[0], sizes[2]),   // 1x4 tiles = 8x32 pixels
+                0x0A => (sizes[1], sizes[2]),   // 2x4 tiles = 16x32 pixels
+                0x0B => (sizes[2], sizes[3]),   // 4x8 tiles = 32x64 pixels
                 _ => throw new FormatException($"Unknown size: 0x{shape:X2}")
             };
         }

--- a/src/JUS.Tool/Graphics/Converters/Dtx3TxToBinary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dtx3TxToBinary.cs
@@ -76,7 +76,10 @@ namespace JUS.Tool.Graphics.Converters
                         writer.WriteOfType<ushort>((ushort)segment.TileIndex);
                         writer.WriteOfType<sbyte>((sbyte)segment.CoordinateX);
                         writer.WriteOfType<sbyte>((sbyte)segment.CoordinateY);
-                        writer.WriteOfType<byte>(GetSize(segment.Width, segment.Height));
+                        byte sizeValue = GetSize(segment.Width, segment.Height);
+                        byte flipValue = GetFlip(segment.HorizontalFlip, segment.VerticalFlip); // already shifted
+                        byte shapeValue = (byte)(sizeValue | flipValue);
+                        writer.WriteOfType<byte>(shapeValue);
                         writer.WriteOfType<sbyte>((sbyte)segment.PaletteIndex);
                     }
                 }

--- a/src/JUS.Tool/Graphics/Converters/Dtx3TxToBinary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dtx3TxToBinary.cs
@@ -14,6 +14,11 @@ namespace JUS.Tool.Graphics.Converters
     /// </summary>
     public class Dtx3TxToBinary : IConverter<NodeContainerFormat, BinaryFormat>
     {
+        private const string Stamp = "DSTX";
+        private const int Version = 0x01;
+        private const int Type = 0x03;
+        private const int PointerOffset = 0x0A;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Dtx3TxToBinary"/> class.
         /// </summary>
@@ -52,16 +57,20 @@ namespace JUS.Tool.Graphics.Converters
             if (SegmentsMetadata == null) {
                 // Obtenemos el DSIG offset
                 reader.Stream.Position = 0x08;
-                uint dsigOffset = reader.ReadUInt16();
+                uint digOffset = reader.ReadUInt16();
                 reader.Stream.Position = 0;
 
                 // Escribimos todo hasta ese offset
-                writer.Write(reader.ReadBytes((int)dsigOffset));
+                writer.Write(reader.ReadBytes((int)digOffset));
             } else {
                 reader.Stream.Position = 0;
 
-                // We copy the first 10 bytes from the original dtx
-                writer.Write(reader.ReadBytes(10));
+                writer.Write(Stamp, false);
+                writer.WriteOfType<byte>((byte)Version);
+                writer.WriteOfType<byte>((byte)Type);
+                writer.WriteOfType<short>((short)SegmentsMetadata.Count);
+                writer.Stream.PushCurrentPosition();
+                writer.WriteOfType<short>((short)0x02); // we'll replace this later
 
                 long segmentInfoOffset = 2 * SegmentsMetadata.Count; // relative to 0x0A
 
@@ -83,6 +92,13 @@ namespace JUS.Tool.Graphics.Converters
                         writer.WriteOfType<sbyte>((sbyte)segment.PaletteIndex);
                     }
                 }
+
+                // Replace the DsigOffset
+                long dsigOffset = writer.Stream.Position;
+
+                writer.Stream.PopPosition();
+                writer.WriteOfType<short>((short)dsigOffset);
+                writer.Stream.Position = dsigOffset;
             }
 
             var imageReader = new DataReader(dtx.Root.Children["image"].TransformWith<Dig2Binary>()

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -158,12 +158,12 @@ namespace JUSToolkit.Graphics
         public ushort NumPaletteLines { get; set; }
 
         /// <summary>
-        /// Gets or sets the PaletteStart value.
+        /// Gets or sets the offset where the Palettes Section starts.
         /// </summary>
         public uint PaletteStart { get; set; }
 
         /// <summary>
-        /// Gets or sets the PixelsStart value.
+        /// Gets or sets the offset where the Pixels Section starts.
         /// </summary>
         public uint PixelsStart { get; set; }
 

--- a/src/JUS.Tool/Utils/HexViewer.cs
+++ b/src/JUS.Tool/Utils/HexViewer.cs
@@ -20,7 +20,7 @@
 using System.IO;
 using System.Text;
 
-namespace JUSToolkit.Graphics.Converters
+namespace JUSToolkit.Utils
 {
     /// <summary>
     /// Hex and ascii viewer by Pleonex.

--- a/src/JUS.Tool/Utils/PaletteDebugger.cs
+++ b/src/JUS.Tool/Utils/PaletteDebugger.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Priverop
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Texim.Pixels;
+
+namespace JUSToolkit.Utils
+{
+    /// <summary>
+    /// Utils to help debugging pixels and palettes.
+    /// </summary>
+    public static class PaletteDebugger
+    {
+        /// <summary>
+        /// Groups the pixels by their color info (color index in palette, alpha/transparency, palette index).
+        /// </summary>
+        /// <param name="pixels">The pixels of the image.</param>
+        public static void GroupAndDisplayPixels(IndexedPixel[] pixels)
+        {
+            var pixelGroups = new Dictionary<string, int>();
+
+            for (int i = 0; i < pixels.Length; i++) {
+                IndexedPixel pixel = pixels[i];
+                string key = $"{pixel.Index},{pixel.Alpha},{pixel.PaletteIndex}";
+
+                if (pixelGroups.ContainsKey(key)) {
+                    pixelGroups[key]++;
+                } else {
+                    pixelGroups[key] = 1;
+                }
+            }
+
+            foreach (KeyValuePair<string, int> group in pixelGroups) {
+                string[] parts = group.Key.Split(',');
+                Console.WriteLine($"You have {group.Value} pixels with Index: {parts[0]}, Alpha: {parts[1]}, P: {parts[2]}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Export DTX03 segments.
- Add a palette debugger to check where is pointing each pixel.
- Fix missing flip values for dtx03tx importing.
- Fix dynamic dsig position when importing dtx03tx.
- Add coloring verbosing to ALAR insertion.