### PR TITLE
docs: improve ALAR format specs

### DIFF
--- a/docs/articles/specs/alar.md
+++ b/docs/articles/specs/alar.md
@@ -1,8 +1,8 @@
 # ALAR container
 
 The _ALAR_ binary format (_AL ARchive_) specifies how to pack binary files
-together. There are three versions of the format, but there are no remains of
-assets with version 1.
+together. There are three versions of the format, but this game only has files
+with version 2 and 3.
 
 ## Format
 
@@ -16,7 +16,7 @@ across versions:
 | 0x05   | byte    | Container feature flags |
 | 0x06   | short   | Number of files         |
 
-The feature flag is a bit-field:
+The feature flag is a bit-field with 8 bits as follows:
 
 - 0: if set, container provides filenames.
 - 1: unknown, set when the container has a file with file info flag bit 24 set.
@@ -98,7 +98,7 @@ There are 16 bytes per file:
 | 0x0C   | uint | File info flags           |
 
 The highest byte of the file ID defines the [format type](#file-types). The rest
-bytes identify the image.
+bytes identify the final asset (like an image).
 
 The file info flags have two parts:
 

--- a/docs/articles/specs/alar.md
+++ b/docs/articles/specs/alar.md
@@ -1,8 +1,8 @@
 # ALAR container
 
 The _ALAR_ binary format (_AL ARchive_) specifies how to pack binary files
-together. There are three versions of the format, although version 1 is used
-anymore (but some blocks of code remains in the games).
+together. There are three versions of the format, but there are no remains of
+assets with version 1.
 
 ## Format
 
@@ -12,7 +12,7 @@ across versions:
 | Offset | Type    | Description             |
 | ------ | ------- | ----------------------- |
 | 0x00   | char[4] | Format ID: `ALAR`       |
-| 0x04   | byte    | Version: `3`            |
+| 0x04   | byte    | Version                 |
 | 0x05   | byte    | Container feature flags |
 | 0x06   | short   | Number of files         |
 
@@ -149,10 +149,10 @@ The file ID and info flags have the same meaning as in
 
 ## Name hashes
 
-The format store a precomputed hash of the file name, to speed up the file
+The format stores a precomputed hash of the file name, to speed up the file
 lookup process. At runtime, the game computes the same hash of the requested
-file path, and compare with the stored value. This is faster than comparing
-paths char by char.
+file path, and compare with the stored value. If it matches, it does also
+compare the name char by char to prevent false positives due to hash collisions.
 
 There are two known versions of the hash algorithm. ALAR version 2 uses the
 first version. ALAR version 3 has a flag in the header to indicate the hash

--- a/docs/articles/specs/alar.md
+++ b/docs/articles/specs/alar.md
@@ -80,7 +80,7 @@ It has two additional 32-bits integers with the first, and last file ID (without
 the type). The last file ID takes into account the frame count from `ALMT` /
 `ALOD` files as it were additional files.
 
-### V2 File info
+#### V2 File info
 
 There are 16 bytes per file:
 
@@ -101,7 +101,7 @@ The file info flags have two parts:
 - bit 30: if set, the lower part contains the frame count
 - bit 31: if set, before the file data there is the file name and hash
 
-### V2 File data
+#### V2 File data
 
 | Offset | Type     | Description               |
 | ------ | -------- | ------------------------- |
@@ -115,7 +115,7 @@ The file info flags have two parts:
 > The path and checksum (if available via file info flags), are 34 bytes before
 > the address of the file data offset.
 
-#### V3
+### Version 3
 
 The format structure is:
 
@@ -133,7 +133,7 @@ The format structure is:
 | 0x10   | short   | Data offset                  |
 | 0x12   | short[] | File info absolute offsets   |
 
-### V3 File info
+#### V3 File info
 
 | Offset | Type     | Description                             |
 | ------ | -------- | --------------------------------------- |

--- a/docs/articles/specs/alar.md
+++ b/docs/articles/specs/alar.md
@@ -6,80 +6,146 @@ anymore (but some blocks of code remains in the games).
 
 ## Format
 
-The format structure is:
+The binary format changes for each version. However, the header remains the same
+across versions:
 
-- Header
-- Padding (multiple of 4)
-- File info table
-- File data
+| Offset | Type    | Description             |
+| ------ | ------- | ----------------------- |
+| 0x00   | char[4] | Format ID: `ALAR`       |
+| 0x04   | byte    | Version: `3`            |
+| 0x05   | byte    | Container feature flags |
+| 0x06   | short   | Number of files         |
 
-### Header
+The feature flag is a bit-field:
 
-| Offset | Type    | Description                   |
-| ------ | ------- | ----------------------------- |
-| 0x00   | char[4] | Format ID: `ALAR`             |
-| 0x04   | byte    | Version: `3`                  |
-| 0x05   | byte    | Flags: `05` or `45`           |
-| 0x06   | short   | Number of files               |
-| 0x08   | int     | Reserved: `0`                 |
-| 0x0C   | short   | Number of entries (files - 1) |
-| 0x10   | short   | Data offset                   |
-| 0x12   | short[] | File info absolute offsets    |
-
-The flag is a bitfield:
-
-- 0: always v2 and v3 (has path?)
-- 1: maybe v2: has filename?
-- 2: always v3: new fileinfo?
+- 0: filename support
+- 1: unknown
+- 2: folder and sub-container (ALAR) support
 - 3-5: reserved
-- 6: maybe v3: if set, use checksum version 2 instead of 1.
+- 6: path hash version: 0=v1, 1=v2
 - 7: reserved
 
 The possible combinations are:
 
-- Version 2:
-  - `0x01`: standard format for v3
-  - `0x03`
-- Version 3:
-  - `0x05`: standard format for v3
-  - `0x45`: use newer file path hash algorithm
+- Version 2: `0x01`, `0x03`
+- Version 3: `0x05`, `0x45`
+
+### Version 1
+
+The format structure is:
+
+- [Header](#format)
+- Extended header
+- Lookup table
+- File access table
+- File data
+
+#### V1 Extender header
+
+It contains of a 32-bits integer with the first file ID.
+
+#### V1 Lookup table
+
+There is one entry per file with the information to find the index of the file
+in the container by path or file ID. The size of each entry depends on the
+container features, if it supports file names or not.
+
+- (only if bit0 is set, for filename support) `char[32]` filename
+- `uint` file ID
+
+#### V1 File access table
+
+There is one entry per file with the absolute offset to the file data. Each
+entry is a 32-bits integer.
+
+#### V1 File data
+
+The file data format is:
+
+- `uint` data size
+- `byte[size]` data
+
+### Version 2
+
+The format structure is:
+
+- [Header](#format)
+- Extended header
+- File info table
+- File data
+
+#### V2 Extended header
+
+It has two additional 32-bits integers with the first, and last file ID (without
+the type). The last file ID takes into account the frame count from `ALMT` /
+`ALOD` files as it were additional files.
 
 ### V2 File info
 
+There are 16 bytes per file:
+
 | Offset | Type | Description               |
 | ------ | ---- | ------------------------- |
-| 0x00   | uint | Global file ID            |
+| 0x00   | uint | File ID                   |
 | 0x04   | uint | File data absolute offset |
 | 0x08   | uint | File data size            |
 | 0x0C   | uint | File info flags           |
 
+The highest byte of the file ID defines the [format type](#file-types).
+
+The file info flags have two parts:
+
+- bits 0-23: frame count
+- bit 24: unknown, only set for some `DSIG` formats
+- bit 25-29: reserved
+- bit 30: if set, the lower part contains the frame count
+- bit 31: if set, before the file data there is the file name and hash
+
 ### V2 File data
 
-| Offset | Type     | Description                |
-| ------ | -------- | -------------------------- |
-| 0x00   | short    | Padding                    |
-| 0x02   | char[32] | Null-terminated file path  |
-| 0x22   | ushort   | [File path hash](#hash-v1) |
-| ...    | Stream   | File data                  |
+| Offset | Type     | Description               |
+| ------ | -------- | ------------------------- |
+| -0x24  | byte[2]  | Padding                   |
+| -0x22  | char[32] | Filename (ASCII)          |
+| -0x02  | ushort   | [Filename hash](#hash-v1) |
+| 0x00   | byte[]   | File data                 |
+
+> [!NOTE]  
+> Different to version 1, the file data offset points to the start of the data.
+> The path and checksum (if available via file info flags), are 34 bytes before
+> the address of the file data offset.
+
+#### V3
+
+The format structure is:
+
+- [Header](#format)
+- Extended header
+- File info table
+- File data
+
+#### V3 Extended header
+
+| Offset | Type    | Description                  |
+| ------ | ------- | ---------------------------- |
+| 0x08   | uint    | First file ID (without type) |
+| 0x0C   | uint    | Last file ID (without type)  |
+| 0x10   | short   | Data offset                  |
+| 0x12   | short[] | File info absolute offsets   |
 
 ### V3 File info
 
 | Offset | Type     | Description                             |
 | ------ | -------- | --------------------------------------- |
-| 0x00   | uint     | Global file ID                          |
+| 0x00   | uint     | File ID                                 |
 | 0x04   | uint     | File data absolute offset               |
 | 0x08   | uint     | File data size                          |
 | 0x0C   | uint     | Flags                                   |
 | 0x10   | ushort   | [File path hash](#name-hashes)          |
 | 0x12   | char[18] | Null-terminated file path ASCII encoded |
 
-The highest 8 bits of the file ID indicate the file type.
-
-The file info flags have two parts:
-
-- bits 0-23: format flags. Usually 1 except for `.amt` files.
-- bits 24-31: entry flags
-  - bit 31: if set, the file info entry contains the checksum and file path.
+The file ID and info flags have the same meaning as in
+[version 2 file info](#v2-file-info).
 
 ## Name hashes
 
@@ -126,3 +192,14 @@ foreach (byte ch in data) {
     hash ^= (ushort)(hash << 1) | ch;
 }
 ```
+
+## File types
+
+- `0x00`: undefined format, specific binary data structure
+- `0x40`: `DSTX`
+- `0x41`: `ALMT`
+- `0x42`: `DSIG`
+- `0x43`: `ALOD`
+- `0x45`: `NCCL`
+- `0x46`: `ALTM`
+- `0x47`: `ALAR`

--- a/docs/articles/specs/alar.md
+++ b/docs/articles/specs/alar.md
@@ -1,150 +1,128 @@
-# ALAR Containers
+# ALAR container
 
-## ALAR 3
+The _ALAR_ binary format (_AL ARchive_) specifies how to pack binary files
+together. There are three versions of the format, although version 1 is used
+anymore (but some blocks of code remains in the games).
 
-This format is useful to store a lot of files. We have the header where we store all the pointers and then we have the file contents all together.
+## Format
 
-| Offset | Type       | Description                       |
-| ------ | ---------- | --------------------------------- |
-| 0x00   | char[4]    | ALAR                              |
-| 0x04   | byte       | Version (3 to follow)             |
-| 0x05   | byte       | Minor version (5, 69)             |
-| 0x06   | int        | Number of files                   |
-| 0x0A   | short      | Reserved?                         |
-| 0x0C   | int        | Number of entries (files - 1)     |
-| 0x10   | short      | Data offset (pointer section end) |
-| 0x12   | short[]    | File info absolute pointers       |
-| ..     | ..         | Padding until 04 multiple         |
-| ..     | FileInfo[] | File info list                    |
-| ..     | Stream[]   | File data                         |
+The format structure is:
 
-### File info
+- Header
+- Padding (multiple of 4)
+- File info table
+- File data
 
-36 bytes
+### Header
 
-| Offset | Type   | Description                 |
-| ------ | ------ | --------------------------- |
-| 0x00   | short  | File ID starting from 0     |
-| 0x02   | short  | Unknown: 040                |
-| 0x04   | int    | Absolute pointer            |
-| 0x08   | int    | Size                        |
-| 0x0C   | int    | Unknown: 01000080           |
-| 0x10   | short  | Unknown***                  |
-| 0x12   | string | Null-terminated file path** |
+| Offset | Type    | Description                   |
+| ------ | ------- | ----------------------------- |
+| 0x00   | char[4] | Format ID: `ALAR`             |
+| 0x04   | byte    | Version: `3`                  |
+| 0x05   | byte    | Flags: `05` or `45`           |
+| 0x06   | short   | Number of files               |
+| 0x08   | int     | Reserved: `0`                 |
+| 0x0C   | short   | Number of entries (files - 1) |
+| 0x10   | short   | Data offset                   |
+| 0x12   | short[] | File info absolute offsets    |
 
-** char FileName[18] // 14bytes string + 4bytes pad to next entry - null terminated
-*** it seems there may be a correlation but i don't know what is it
-### Example
+The flag is a bitfield:
 
-koma.aar
+- 0: always v2 and v3 (has path?)
+- 1: maybe v2: has filename?
+- 2: always v3: new fileinfo?
+- 3-5: reserved
+- 6: maybe v3: if set, use checksum version 2 instead of 1.
+- 7: reserved
 
-| Offset | Size | Hex      | Description             | Content (Hex) | Content (Decimal) |
-| ------ | ---- | -------- | ----------------------- | ------------- | ----------------- |
-| 0x00   | 4    | 414C4152 | ALAR                    |
-| 0x04   | 1    | 03       | Version                 |
-| 0x05   | 1    | 05       | Minor Version           |
-| 0x06   | 4    | 82030000 | Number of Files         | 382           | 898               |
-| 0x0A   | 2    | 000000   | Reserved                |
-| 0x0C   | 4    | 81030000 | Number of entries       | 381           | 897               |
-| 0x10   | 2    | 6085     | Data Offset             | 8560          |
-| 0x12   | 2    | 1807     | File info first pointer | 718           |
+The possible combinations are:
 
-First file: koma/bb_00.dtx
+- Version 2:
+  - `0x01`: standard format for v3
+  - `0x03`
+- Version 3:
+  - `0x05`: standard format for v3
+  - `0x45`: use newer file path hash algorithm
 
-| Offset | Size | Hex      | Description                 | Content (Hex) | Content (Decimal) |
-| ------ | ---- | -------- | --------------------------- | ------------- | ----------------- |
-| 0x718  | 2    | 0000     | ID                          |
-| 0x71A  | 2    | 0040     | Unknown                     | 40            |
-| 0x71C  | 4    | 60850000 | Absolute Pointer            | 8560          |
-| 0x720  | 4    | DC040000 | Size                        | 04DC          | 1244              |
-| 0x724  | 4    | 01000080 | Unknown                     |
-| 0x728  | 2    | 3C96     | Unknown                     |
-| 0x72A  | 18   | 1807     | File path: koma/bb_00.dtx** |
+### V2 File info
 
-** The real size is 14bytes but we have a 00 byte (null terminated)
+| Offset | Type | Description               |
+| ------ | ---- | ------------------------- |
+| 0x00   | uint | Global file ID            |
+| 0x04   | uint | File data absolute offset |
+| 0x08   | uint | File data size            |
+| 0x0C   | uint | File info flags           |
 
-## ALAR 2
+### V2 File data
 
-This format is used for pack files inside of ALAR 3 pack files. We have a small header, the info of the files and then the files one after another.
+| Offset | Type     | Description                |
+| ------ | -------- | -------------------------- |
+| 0x00   | short    | Padding                    |
+| 0x02   | char[32] | Null-terminated file path  |
+| 0x22   | ushort   | [File path hash](#hash-v1) |
+| ...    | Stream   | File data                  |
 
-| Offset | Type                 | Description          |
-| ------ | -------------------- | -------------------- |
-| 0x00   | char[4]              | ALAR                 |
-| 0x04   | byte                 | Version (2)          |
-| 0x05   | byte                 | Minor version (1, 3) |
-| 0x06   | short                | Number of files      |
-| 0x08   | byte[8]              | IDs?                 |
-| 0x10   | FileInfo[fileNumber] | File info list       |
-| ...    | FileData[fileNumber] | File data            |
+### V3 File info
 
-### File Info
+| Offset | Type     | Description                             |
+| ------ | -------- | --------------------------------------- |
+| 0x00   | uint     | Global file ID                          |
+| 0x04   | uint     | File data absolute offset               |
+| 0x08   | uint     | File data size                          |
+| 0x0C   | uint     | Flags                                   |
+| 0x10   | ushort   | [File path hash](#name-hashes)          |
+| 0x12   | char[18] | Null-terminated file path ASCII encoded |
 
-16 bytes
+The highest 8 bits of the file ID indicate the file type.
 
-| Offset | Type | Description      |
-| ------ | ---- | ---------------- |
-| 0x00   | int  | Unknown? Type?   |
-| 0x04   | int  | Absolute pointer |
-| 0x08   | int  | Size             |
-| 0x0A   | int  | Unknown          |
+The file info flags have two parts:
 
-### File Data
+- bits 0-23: format flags. Usually 1 except for `.amt` files.
+- bits 24-31: entry flags
+  - bit 31: if set, the file info entry contains the checksum and file path.
 
-36 bytes
+## Name hashes
 
-| Offset | Type              | Description                         |
-| ------ | ----------------- | ----------------------------------- |
-| 0x00   | short             | Unknown, padding?                   |
-| 0x02   | string (32 bytes) | Null-terminated file path + padding |
-| ...    | short             | Unknown                             |
-| ...    | Stream            | File Data                           |
+The format store a precomputed hash of the file name, to speed up the file
+lookup process. At runtime, the game computes the same hash of the requested
+file path, and compare with the stored value. This is faster than comparing
+paths char by char.
 
-### Example
+There are two known versions of the hash algorithm. ALAR version 2 uses the
+first version. ALAR version 3 has a flag in the header to indicate the hash
+version.
 
-deck_obj.aar
+> [!NOTE]  
+> In both versions, the hash is over the path of the file inside the ALAR
+> container **without the file extension**. If the ALAR contains a file
+> `data/file.bin`, the game computes the hash over `data/file`. The text
+> encoding is ASCII. There is also a limit of 32 bytes. Longer paths are
+> truncated.
 
-Header
+> [!WARNING]  
+> It seems the first version causes some issues (hash collisions?). The game
+> disabled file lookup by hash, when the ALAR used version 1. In those cases, it
+> performs a full path comparison char by char.
 
-| Offset | Size | Hex               | Description     | Content (Hex) | Content (Decimal) |
-| ------ | ---- | ----------------- | --------------- | ------------- | ----------------- |
-| 0x00   | 4    | 414C4152          | ALAR            |
-| 0x04   | 1    | 02                | Version         |
-| 0x05   | 1    | 01                | Minor Version   |
-| 0x06   | 2    | 0200              | Number of Files | 2             | 2                 |
-| 0x08   | 8    | 00006800 09006800 | IDs             |
+### Hash v1
 
-File info #1
+```csharp
+byte[] data = Encoding.ASCII.GetBytes(pathWithoutExtension);
 
-| Offset | Size | Hex      | Description      | Content (Hex) | Content (Decimal) |
-| ------ | ---- | -------- | ---------------- | ------------- | ----------------- |
-| 0x10   | 4    | 00006840 | ID               |
-| 0x14   | 4    | 54000000 | Absolute Pointer | 54            |
-| 0x18   | 4    | DC010000 | Size             | 1DC           | 476               |
-| 0x1C   | 4    | 01000080 | Unknown          |
+uint hash = 0;
+foreach (byte ch in data) {
+    uint tmp = (hash << 1) ^ ch;
+    hash = (tmp & 0xFFFF) ^ (tmp >> 16);
+}
+```
 
-File info #2
+### Hash v2
 
-| Offset | Size | Hex      | Description      | Content (Hex) | Content (Decimal) |
-| ------ | ---- | -------- | ---------------- | ------------- | ----------------- |
-| 0x20   | 4    | 00006840 | ID               |
-| 0x24   | 4    | 54020000 | Absolute Pointer | 254           |
-| 0x28   | 4    | 10010000 | Size             | 110           | 272               |
-| 0x2C   | 4    | 0A0000C0 | Unknown          |
+```csharp
+byte[] data = Encoding.ASCII.GetBytes(pathWithoutExtension);
 
-File data #1: deck_obj.dtx
-
-| Offset | Size | Hex                                   | Description      |
-| ------ | ---- | ------------------------------------- | ---------------- |
-| 0x30   | 2    | 0000                                  | Unkown, padding? |
-| 0x32   | 32   | 6465636B 5F6F626A 2E647478 + 20 zeros | deck_obj.dtx     |
-| 0x52   | 2    | 7A22                                  | Unknown          |
-| 0x54   | 476  | 44535458...                           | Stream           |
-
-File data #2: deck_obj.amt
-
-| Offset | Size | Hex                                   | Description      |
-| ------ | ---- | ------------------------------------- | ---------------- |
-| 0x230  | 2    | 0000                                  | Unkown, padding? |
-| 0x232  | 32   | 6465636B 5F6F626A 2E616D74 + 20 zeros | deck_obj.amt     |
-| 0x252  | 2    | 7A22                                  | Unknown          |
-| 0x254  | 272  | 44535458...                           | Stream           |
+uint hash = 0;
+foreach (byte ch in data) {
+    hash ^= (ushort)(hash << 1) | ch;
+}
+```

--- a/docs/articles/specs/alar.md
+++ b/docs/articles/specs/alar.md
@@ -18,27 +18,27 @@ across versions:
 
 The feature flag is a bit-field:
 
-- 0: filename support
-- 1: unknown
-- 2: folder and sub-container (ALAR) support
-- 3-5: reserved
-- 6: path hash version: 0=v1, 1=v2
-- 7: reserved
+- 0: if set, container provides filenames.
+- 1: unknown, set when the container has a file with file info flag bit 24 set.
+- 2: if set, container supports folders and sub-container (ALAR).
+- 3-5: reserved.
+- 6: [file path hash](#file-path-hashes) version: 0=v1, 1=v2.
+- 7: reserved.
 
-The possible combinations are:
+The combinations found in the game assets are:
 
-- Version 2: `0x01`, `0x03`
-- Version 3: `0x05`, `0x45`
+- Version 2: `0x01`, `0x03`.
+- Version 3: `0x05`, `0x45`.
 
 ### Version 1
 
 The format structure is:
 
-- [Header](#format)
-- Extended header
-- Lookup table
-- File access table
-- File data
+- [Header](#format).
+- Extended header.
+- Lookup table.
+- File access table.
+- File data.
 
 #### V1 Extender header
 
@@ -50,8 +50,8 @@ There is one entry per file with the information to find the index of the file
 in the container by path or file ID. The size of each entry depends on the
 container features, if it supports file names or not.
 
-- (only if bit0 is set, for filename support) `char[32]` filename
-- `uint` file ID
+- (only if bit0 is set, for filename support) `char[32]` filename.
+- `uint` file ID.
 
 #### V1 File access table
 
@@ -62,23 +62,29 @@ entry is a 32-bits integer.
 
 The file data format is:
 
-- `uint` data size
-- `byte[size]` data
+- `uint` data size.
+- `byte[size]` data.
 
 ### Version 2
 
 The format structure is:
 
-- [Header](#format)
-- Extended header
-- File info table
-- File data
+- [Header](#format).
+- Extended header.
+- File info table.
+- File data.
 
 #### V2 Extended header
 
-It has two additional 32-bits integers with the first, and last file ID (without
-the type). The last file ID takes into account the frame count from `ALMT` /
-`ALOD` files as it were additional files.
+There are four additional bytes:
+
+| Offset | Type | Description                  |
+| ------ | ---- | ---------------------------- |
+| 0x08   | uint | First file ID (without type) |
+| 0x0C   | uint | Last file ID (without type)  |
+
+The last file ID takes into account the frame count from `ALMT` / `ALOD` files
+as it were additional files.
 
 #### V2 File info
 
@@ -91,15 +97,17 @@ There are 16 bytes per file:
 | 0x08   | uint | File data size            |
 | 0x0C   | uint | File info flags           |
 
-The highest byte of the file ID defines the [format type](#file-types).
+The highest byte of the file ID defines the [format type](#file-types). The rest
+bytes identify the image.
 
 The file info flags have two parts:
 
-- bits 0-23: frame count
-- bit 24: unknown, only set for some `DSIG` formats
-- bit 25-29: reserved
-- bit 30: if set, the lower part contains the frame count
-- bit 31: if set, before the file data there is the file name and hash
+- bits 0-23: _frame count_ if bit 30 is set, otherwise `1`.
+  - This seems to be set only for `ALMT` and `ALOD` files.
+- bit 24: unknown, only set for some `DSIG` formats.
+- bit 25-29: reserved.
+- bit 30: if set, the bits 0-23 define the frame count.
+- bit 31: if set, before the file data there is the file name and hash.
 
 #### V2 File data
 
@@ -119,10 +127,10 @@ The file info flags have two parts:
 
 The format structure is:
 
-- [Header](#format)
-- Extended header
-- File info table
-- File data
+- [Header](#format).
+- Extended header.
+- File info table.
+- File data.
 
 #### V3 Extended header
 
@@ -141,18 +149,18 @@ The format structure is:
 | 0x04   | uint     | File data absolute offset               |
 | 0x08   | uint     | File data size                          |
 | 0x0C   | uint     | Flags                                   |
-| 0x10   | ushort   | [File path hash](#name-hashes)          |
+| 0x10   | ushort   | [File path hash](#file-path-hashes)     |
 | 0x12   | char[18] | Null-terminated file path ASCII encoded |
 
 The file ID and info flags have the same meaning as in
 [version 2 file info](#v2-file-info).
 
-## Name hashes
+## File path hashes
 
-The format stores a precomputed hash of the file name, to speed up the file
-lookup process. At runtime, the game computes the same hash of the requested
-file path, and compare with the stored value. If it matches, it does also
-compare the name char by char to prevent false positives due to hash collisions.
+The format stores a precomputed hash of the file path in the container, to speed
+up the file lookup process. At runtime, the game computes the same hash of the
+requested path, and compares with the stored value. If it matches, it does also
+compare the path char by char to prevent false positives due to hash collisions.
 
 There are two known versions of the hash algorithm. ALAR version 2 uses the
 first version. ALAR version 3 has a flag in the header to indicate the hash
@@ -195,7 +203,7 @@ foreach (byte ch in data) {
 
 ## File types
 
-- `0x00`: undefined format, specific binary data structure
+- `0x00`: undefined format, specific binary data structure.
 - `0x40`: `DSTX`
 - `0x41`: `ALMT`
 - `0x42`: `DSIG`

--- a/docs/articles/specs/koma.md
+++ b/docs/articles/specs/koma.md
@@ -38,34 +38,6 @@ The sprite data is 4 bytes:
 | 0x0C   | bgr555[] | palette                                            |
 | ...    | pixels[] | image                                              |
 
-## ALAR 3
-
-| Offset | Type       | Description                 |
-| ------ | ---------- | --------------------------- |
-| 0x00   | char[4]    | ALAR                        |
-| 0x04   | byte       | Version (3 to follow)       |
-| 0x05   | byte       | Minor version?              |
-| 0x06   | int        | Number of files             |
-| 0x0A   | short      | Reserved?                   |
-| 0x0C   | int        | Number of entries           |
-| 0x10   | short      | Data offset                 |
-| 0x12   | short[]    | File info absolute pointers |
-| ..     | FileInfo[] | File info list              |
-| ..     | Stream[]   | File data                   |
-
-### File info
-
-| Offset | Type   | Description               |
-| ------ | ------ | ------------------------- |
-| 0x00   | short  | ID                        |
-| 0x02   | short  | Unknown                   |
-| 0x04   | int    | Absolute pointer          |
-| 0x08   | int    | Size                      |
-| 0x0C   | short  | Unknown                   |
-| 0x0E   | short  | Unknown                   |
-| 0x10   | short  | Unknown                   |
-| 0x12   | string | Null-terminated file path |
-
 ## KShape
 
 | Offset | Type         | Description                 |

--- a/docs/articles/specs/summary.md
+++ b/docs/articles/specs/summary.md
@@ -3,6 +3,12 @@
 This section list the game assets and their format. You can find more
 information about the specification in each sub-page.
 
+> [!INFO]  
+> **AL**  
+> There are several formats and debug text in the game with the prefix `AL`.
+> This could have been the internal code name of the game, or the game engine
+> name.
+
 ## Containers
 
 Most of the assets are packed with the [`ALAR` container format](./alar.md).

--- a/docs/articles/specs/summary.md
+++ b/docs/articles/specs/summary.md
@@ -3,7 +3,7 @@
 This section list the game assets and their format. You can find more
 information about the specification in each sub-page.
 
-> [!INFO]  
+> [!TIP]  
 > **AL**  
 > There are several formats and debug text in the game with the prefix `AL`.
 > This could have been the internal code name of the game, or the game engine

--- a/docs/articles/specs/toc.yml
+++ b/docs/articles/specs/toc.yml
@@ -3,7 +3,7 @@
   href: ./summary.md
 
 - name: 📁 Containers
-- name: AAR / ALAR
+- name: ALAR
   href: alar.md
 #- name: TODO: DSCP
 #  href: dscp.md


### PR DESCRIPTION
### Description

Document unknown fields of the ALAR format. It also includes a guess of how the v1 format should look like from the remainings of unused code left.

There are still some unknown bits. We will have a better guess once we know more about the .amt and .dig formats.