### PR TITLE
fix: menu images mergedig

### DIFF
--- a/src/JUS.CLI/JUS/Graphics/DigCommands.cs
+++ b/src/JUS.CLI/JUS/Graphics/DigCommands.cs
@@ -96,60 +96,21 @@ namespace JUS.CLI.JUS.Graphics
                 throw new FormatException("Number of input PNGs does not match number of provided ATMs.");
             }
 
-            // 1 - Get the DIG
-            Dig mergedImage = NodeFactory.FromFile(dig)
-                .TransformWith<LzssDecompression>()
-                .TransformWith<Binary2Dig>()
-                .GetFormatAs<Dig>();
+            Node originalDig = NodeFactory.FromFile(dig, FileOpenMode.Read);
 
-            var compressionParams = new RgbImageMapCompressionParams {
-                Palettes = mergedImage,
-            };
-
-            IndexedImage? newImage = null;
-
-            // 2 - Iterate the input PNGs
+            var originalAtms = new Node[atm.Length];
+            var pngs = new Node[input.Length];
             for (int i = 0; i < input.Length; i++) {
-                // Transform the PNG into RgbImage (Pixels + Map) using the palette of the original DIG
-                MapCompressedIndexedImage compressed = NodeFactory.FromFile(input[i], FileOpenMode.Read)
-                    .TransformWith<StandardBinaryImage2RgbImage>()
-                    .TransformWith(new RgbImageMapCompression(compressionParams))
-                    .GetFormatAs<MapCompressedIndexedImage>();
-
-                newImage = new IndexedImage {
-                    Width = 8,
-                    Height = compressed.Tiles.Length / 8,
-                    Pixels = compressed.Tiles,
-                };
-                ITileMap map = compressed.Map;
-
-                // 3 - Clone original
-                mergedImage = new Dig(mergedImage, newImage);
-
-                if (insertTransparent && i == 0) {
-                    mergedImage = mergedImage.InsertTransparentTile(map);
-                }
-
-                compressionParams = new RgbImageMapCompressionParams {
-                    MergeImage = mergedImage,
-                    Palettes = mergedImage,
-                };
-
-                // New Atm: original atm changing height, width and maps
-                Altm originalAtm = NodeFactory.FromFile(atm[i], FileOpenMode.Read)
-                    .TransformWith<Binary2Altm>()
-                    .GetFormatAs<Altm>();
-                var newAtm = new Altm(originalAtm, map);
-
-                // Export ATM
-                new Altm2Binary().Convert(newAtm)
-                    .Stream.WriteTo(Path.Combine(output, Path.GetFileName(atm[i])));
+                originalAtms[i] = NodeFactory.FromFile(atm[i], FileOpenMode.Read);
+                pngs[i] = NodeFactory.FromFile(input[i], FileOpenMode.Read);
             }
 
-            // New Dig: original dig changing height, width and pixels
-            var newDig = new Dig(mergedImage, newImage!);
-            new Dig2Binary().Convert(newDig)
-                .Stream.WriteTo(Path.Combine(output, Path.GetFileName(dig)));
+            var converter = new Png2DigAtm(originalDig, originalAtms, insertTransparent);
+            NodeContainerFormat transformedFiles = converter.Convert(pngs);
+
+            foreach (Node file in transformedFiles.Root.Children) {
+                file.Stream.WriteTo(Path.Combine(output, file.Name));
+            }
 
             Console.WriteLine("Done!");
         }

--- a/src/JUS.CLI/JUS/Rom/MenuImageFile.cs
+++ b/src/JUS.CLI/JUS/Rom/MenuImageFile.cs
@@ -96,10 +96,18 @@ namespace JUS.CLI.JUS.Rom
 
             originalAlar.TransformWith<Binary2Alar3>();
 
-            foreach (Node fileToInsert in filesToInsert) {
-                string[] imageInfo = ContainerLocations[fileToInsert.Name];
-                fileToInsert.Name = StringFunctions.GetOriginalName(fileToInsert.Name);
-                originalAlar.TransformWith(new Png2Alar3(fileToInsert, imageInfo[0], imageInfo[1]));
+            // Some images can share the same dig, so they have to be inserted together
+            var filesGroupedByDig = filesToInsert.GroupBy(x => ContainerLocations[x.Name][0]);
+
+            foreach (var digGroup in filesGroupedByDig) {
+                string[] atmNames = digGroup.Select(x => ContainerLocations[x.Name][1]).ToArray();
+                Node[] pngs = digGroup.ToArray();
+
+                foreach (Node png in pngs) {
+                    png.Name = StringFunctions.GetOriginalName(png.Name);
+                }
+
+                originalAlar.TransformWith(new Png2Alar3(pngs, digGroup.Key, atmNames, false));
             }
 
             originalAlar.TransformWith(new Alar3ToBinary());

--- a/src/JUS.CLI/JUS/Rom/MenuImageFile.cs
+++ b/src/JUS.CLI/JUS/Rom/MenuImageFile.cs
@@ -101,16 +101,16 @@ namespace JUS.CLI.JUS.Rom
 
             foreach (var digGroup in filesGroupedByDig) {
                 string[] atmNames = digGroup.Select(x => ContainerLocations[x.Name][1]).ToArray();
-                Node[] pngs = digGroup.ToArray();
+                Node[] pngs = [.. digGroup];
 
                 foreach (Node png in pngs) {
                     png.Name = StringFunctions.GetOriginalName(png.Name);
                 }
 
-                originalAlar.TransformWith(new Png2Alar3(pngs, digGroup.Key, atmNames, false));
+                _ = originalAlar.TransformWith(new Png2Alar3(pngs, digGroup.Key, atmNames, false));
             }
 
-            originalAlar.TransformWith(new Alar3ToBinary());
+            _ = originalAlar.TransformWith(new Alar3ToBinary());
         }
     }
 }

--- a/src/JUS.Tool/BatchConverters/Png2Alar3.cs
+++ b/src/JUS.Tool/BatchConverters/Png2Alar3.cs
@@ -40,9 +40,9 @@ namespace JUS.Tool.BatchConverters
         /// <param name="insertTransparent">Label to add a transparent pixel in the image.</param>
         public Png2Alar3(Node image, string digName, string atmName, bool insertTransparent)
         {
-            Image = image;
+            Images = [image];
             DigName = digName;
-            AtmName = atmName;
+            AtmNames = [atmName];
             TransparentTile = insertTransparent;
         }
 
@@ -54,16 +54,31 @@ namespace JUS.Tool.BatchConverters
         /// <param name="atmName">Name of the atm.</param>
         public Png2Alar3(Node image, string digName, string atmName)
         {
-            Image = image;
+            Images = [image];
             DigName = digName;
-            AtmName = atmName;
+            AtmNames = [atmName];
             TransparentTile = false;
         }
 
         /// <summary>
-        /// Gets or sets the PNG we are inserting.
+        /// Initializes a new instance of the <see cref="Png2Alar3"/> class for
+        /// multiple PNGs sharing the same Dig.
+        /// <param name="images">PNGs to insert.</param>
+        /// <param name="digName">Name of the shared Dig.</param>
+        /// <param name="atmNames">Name of each atm.</param>
+        /// <param name="insertTransparent">Label to add a transparent pixel in the image.</param>
+        public Png2Alar3(Node[] images, string digName, string[] atmNames, bool insertTransparent)
+        {
+            Images = images;
+            DigName = digName;
+            AtmNames = atmNames;
+            TransparentTile = insertTransparent;
+        }
+
+        /// <summary>
+        /// Gets or sets the PNGs we are inserting.
         /// </summary>
-        public Node Image { get; set; }
+        public Node[] Images { get; set; }
 
         /// <summary>
         /// Gets or sets the original name of the Dig of the image.
@@ -71,9 +86,9 @@ namespace JUS.Tool.BatchConverters
         public string DigName { get; set; }
 
         /// <summary>
-        /// Gets or sets the original name of the Atm of the image.
+        /// Gets or sets the original name of the Atm of each image.
         /// </summary>
-        public string AtmName { get; set; }
+        public string[] AtmNames { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether gets or sets a value indicating the transparent pixel mode.
@@ -87,22 +102,29 @@ namespace JUS.Tool.BatchConverters
         /// <returns><see cref="Alar"/>Alar3 with the PNG inserted.</returns>
         public Alar Convert(Alar originalAlar)
         {
-            if (Path.GetExtension(Image.Name) != ".png") {
-                throw new FormatException("Invalid png file");
+            foreach (Node image in Images) {
+                if (Path.GetExtension(image.Name) != ".png") {
+                    throw new FormatException("Invalid png file");
+                }
             }
 
             // Obtaining the original Dig and Altm
             Node dig = Navigator.IterateNodes(originalAlar.Root).First(n => n.Name == DigName) ?? throw new FormatException("Dig doesn't exist: " + DigName);
-            Node atm = Navigator.IterateNodes(originalAlar.Root).First(n => n.Name == AtmName) ?? throw new FormatException("Atm doesn't exist: " + AtmName);
 
             // Clone the nodes
             var dig_clone = (BinaryFormat)new BinaryFormat(dig.Stream).DeepClone();
-            var atm_clone = (BinaryFormat)new BinaryFormat(atm.Stream).DeepClone();
 
-            // Transform the PNG into the new Dig and Altm (we need the original dig + atm)
-            var converter = new Png2DigAtm(new Node(dig.Name, dig_clone), new Node(atm.Name, atm_clone), true);
+            var atm_clones = new Node[AtmNames.Length];
+            for (int i = 0; i < AtmNames.Length; i++) {
+                Node atm = Navigator.IterateNodes(originalAlar.Root).First(n => n.Name == AtmNames[i]) ?? throw new FormatException("Atm doesn't exist: " + AtmNames[i]);
+                var atm_clone = (BinaryFormat)new BinaryFormat(atm.Stream).DeepClone();
+                atm_clones[i] = new Node(atm.Name, atm_clone);
+            }
 
-            NodeContainerFormat transformedFiles = converter.Convert(Image);
+            // Transform the PNGs into the new Dig and Altms (we need the original dig + atms)
+            var converter = new Png2DigAtm(new Node(dig.Name, dig_clone), atm_clones, true);
+
+            NodeContainerFormat transformedFiles = converter.Convert(Images);
 
             originalAlar.InsertModification(transformedFiles);
 

--- a/src/JUS.Tool/Graphics/Converters/Png2DigAtm.cs
+++ b/src/JUS.Tool/Graphics/Converters/Png2DigAtm.cs
@@ -12,10 +12,12 @@ namespace JUS.Tool.Graphics.Converters
     /// <summary>
     /// Converter to import a PNG image into a Dig + Atm.
     /// </summary>
-    public class Png2DigAtm : IConverter<Node, NodeContainerFormat>
+    public class Png2DigAtm :
+        IConverter<Node, NodeContainerFormat>,
+        IConverter<Node[], NodeContainerFormat>
     {
         private readonly Node originalDig;
-        private readonly Node originalAtm;
+        private readonly Node[] originalAtms;
 
         /// <summary>
         /// Gets or sets the first transparent pixel mode.
@@ -23,15 +25,29 @@ namespace JUS.Tool.Graphics.Converters
         public bool TransparentTile { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Png2DigAtm"/> converter.
+        /// Initializes a new instance of the <see cref="Png2DigAtm"/> converter for a single PNG.
         /// </summary>
         /// <param name="dig">Original Dig.</param>
-        /// <param name="atm">Original Atm.</param>
+        /// <param name="atm">Original Atm (tilemap).</param>
         /// <param name="insertTransparent">The first pixel of the image is transparent.</param>
         public Png2DigAtm(Node dig, Node atm, bool insertTransparent)
         {
             originalDig = dig;
-            originalAtm = atm;
+            originalAtms = [atm];
+            TransparentTile = insertTransparent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Png2DigAtm"/> converter for multiple
+        /// PNGs sharing the same Dig.
+        /// </summary>
+        /// <param name="dig">Original Dig, shared by all the atms.</param>
+        /// <param name="atms">Original Atms (tilemaps).</param>
+        /// <param name="insertTransparent">The first pixel of the image is transparent.</param>
+        public Png2DigAtm(Node dig, Node[] atms, bool insertTransparent)
+        {
+            originalDig = dig;
+            originalAtms = atms;
             TransparentTile = insertTransparent;
         }
 
@@ -45,6 +61,23 @@ namespace JUS.Tool.Graphics.Converters
         {
             ArgumentNullException.ThrowIfNull(png);
 
+            return Convert([png]);
+        }
+
+        /// <summary>
+        /// Imports all the pngs into a single Dig + multiple Atms.
+        /// </summary>
+        /// <param name="pngs">The Nodes with the pngs to import.</param>
+        /// <returns>NFC with the Dig and the Atms.</returns>
+        /// <exception cref="ArgumentException">If pngs is null.</exception>
+        public NodeContainerFormat Convert(Node[] pngs)
+        {
+            ArgumentNullException.ThrowIfNull(pngs);
+
+            if (pngs.Length != originalAtms.Length) {
+                throw new FormatException("Number of pngs and atms is different.");
+            }
+
             var decompression = new LzssDecompression();
 
             // Dig
@@ -52,56 +85,65 @@ namespace JUS.Tool.Graphics.Converters
             BinaryFormat uncompressedDig = decompression.Convert(originalDig.GetFormatAs<IBinary>());
             Dig dig = new Binary2Dig().Convert(uncompressedDig) ?? throw new FormatException("Invalid dig file");
 
-            // Atm
-            bool atmIsCompressed = CompressionUtils.IsCompressed(originalAtm);
-            BinaryFormat uncompressedAtm = decompression.Convert(originalAtm.GetFormatAs<IBinary>());
-            Altm atm = new Binary2Altm().Convert(uncompressedAtm) ?? throw new FormatException("Invalid atm file");
-
             // Convert PNG into a RgbImage (Pixels + Map) using the Dig Palette
+            int paletteIndexStart = FirstNonBlackPaletteIndex(dig);
             var compressionParams = new RgbImageMapCompressionParams {
                 Palettes = dig,
-                PaletteIndexStart = FirstNonBlackPaletteIndex(dig),
+                PaletteIndexStart = paletteIndexStart,
             };
 
-            png.Stream.Position = 0;
-            RgbImage rgbImage = new StandardBinaryImage2RgbImage().Convert(png.GetFormatAs<IBinary>());
-            MapCompressedIndexedImage compressed = new RgbImageMapCompression(compressionParams).Convert(rgbImage);
+            var transformedFiles = new NodeContainerFormat();
 
-            var newImage = new IndexedImage {
-                Width = 8,
-                Height = compressed.Tiles.Length / 8,
-                Pixels = compressed.Tiles,
-            };
-            ITileMap map = compressed.Map;
+            for (int i = 0; i < pngs.Length; i++) {
+                pngs[i].Stream.Position = 0;
+                RgbImage rgbImage = new StandardBinaryImage2RgbImage().Convert(pngs[i].GetFormatAs<IBinary>());
+                MapCompressedIndexedImage compressed = new RgbImageMapCompression(compressionParams).Convert(rgbImage);
 
-            // New Dig: original dig changing height, width and pixels
-            var newDig = new Dig(dig, newImage);
+                var newImage = new IndexedImage {
+                    Width = 8,
+                    Height = compressed.Tiles.Length / 8,
+                    Pixels = compressed.Tiles,
+                };
+                ITileMap map = compressed.Map;
 
-            if (TransparentTile) {
-                newDig = newDig.InsertTransparentTile(map);
+                // New Dig: original dig changing height, width and pixels
+                dig = new Dig(dig, newImage);
+
+                if (TransparentTile && i == 0) {
+                    dig = dig.InsertTransparentTile(map);
+                }
+
+                compressionParams = new RgbImageMapCompressionParams {
+                    MergeImage = dig,
+                    Palettes = dig,
+                    PaletteIndexStart = paletteIndexStart,
+                };
+
+                // Atm
+                bool atmIsCompressed = CompressionUtils.IsCompressed(originalAtms[i]);
+                BinaryFormat uncompressedAtm = decompression.Convert(originalAtms[i].GetFormatAs<IBinary>());
+                Altm atm = new Binary2Altm().Convert(uncompressedAtm) ?? throw new FormatException("Invalid atm file");
+
+                // New Atm: original atm changing height, width and maps
+                var newAtm = new Altm(atm, map);
+                BinaryFormat binaryAtm = new Altm2Binary().Convert(newAtm);
+
+                BinaryFormat compressedAtm = atmIsCompressed ?
+                    new LzssCompression().Convert(binaryAtm) :
+                    binaryAtm;
+
+                transformedFiles.Root.Add(new Node(originalAtms[i].Name, compressedAtm));
             }
 
-            newDig.CheckMaxTiles(originalDig.Name);
+            dig.CheckMaxTiles(originalDig.Name);
 
-            BinaryFormat binaryDig = new Dig2Binary().Convert(newDig);
+            BinaryFormat binaryDig = new Dig2Binary().Convert(dig);
 
             BinaryFormat compressedDig = digIsCompressed ?
                 new LzssCompression().Convert(binaryDig) :
                 binaryDig;
 
-            var transformedFiles = new NodeContainerFormat();
-
             transformedFiles.Root.Add(new Node(originalDig.Name, compressedDig));
-
-            // New Atm: original atm changing height, width and maps
-            var newAtm = new Altm(atm, map);
-            BinaryFormat binaryAtm = new Altm2Binary().Convert(newAtm);
-
-            BinaryFormat compressedAtm = atmIsCompressed ?
-                new LzssCompression().Convert(binaryAtm) :
-                binaryAtm;
-
-            transformedFiles.Root.Add(new Node(originalAtm.Name, compressedAtm));
 
             return transformedFiles;
         }


### PR DESCRIPTION
### Description

Some menu images needed MergeDig (import multiple PNGs with the same Dig).

I refactored everything to encapsulate the logic. Now our converters allow from regular importing (1png = 1 dig + 1 atm) and multiple.

I used Node[] instead of NFC and searching by name, because in the Strategy the files are grouped and it's easier. However, I'll test this more in the future.
