### PR TITLE
feat(dsig): complete DSIG specification implementation, fix SceneGate discovery

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -230,7 +230,7 @@ dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
 ### SonarAnalyzer
 dotnet_diagnostic.S1133.severity = suggestion # Remove deprecated code -.-' I know, some day
 dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
-dotnet_diagnostic.S3236.severity = suggestion # Custom paran name for actions
+dotnet_diagnostic.S3236.severity = suggestion # Custom param name for actions
 dotnet_diagnostic.S3267.severity = suggestion # Simplify loops nope for readability
 dotnet_diagnostic.S6444.severity = suggestion # Mandatory timeout for regex... It's ok
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -230,6 +230,7 @@ dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
 ### SonarAnalyzer
 dotnet_diagnostic.S1133.severity = suggestion # Remove deprecated code -.-' I know, some day
 dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
+dotnet_diagnostic.S3236.severity = suggestion # Custom paran name for actions
 dotnet_diagnostic.S3267.severity = suggestion # Simplify loops nope for readability
 dotnet_diagnostic.S6444.severity = suggestion # Mandatory timeout for regex... It's ok
 

--- a/.idea/.idea.JUSToolkit/.idea/.gitignore
+++ b/.idea/.idea.JUSToolkit/.idea/.gitignore
@@ -13,3 +13,4 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+/.name

--- a/docs/articles/specs/dsig.md
+++ b/docs/articles/specs/dsig.md
@@ -17,7 +17,7 @@ games only handles version 2 when the flags value is `0x40`.
 | 0x04   | byte       | Version: 1 or 2                                   |
 | 0x05   | byte       | Flags                                             |
 | 0x06   | byte       | Number of palettes                                |
-| 0x07   | byte       | Unknown (0 or 4)                                  |
+| 0x07   | byte       | Color encoding                                    |
 | 0x08   | ushort     | Image width or block info length / 4 in format 4  |
 | 0x0A   | ushort     | Image height or block data length / 4 in format 4 |
 | 0x0C   | bgr555[][] | Palettes                                          |
@@ -63,8 +63,16 @@ And there is one additional unknown implementation with name `NCG2`.
 
 ### Palettes
 
-Every palette has 16 colors. Each color is a 16-bits value with BGR555 encoding.
-In 8bpp, the palettes are combined into one.
+Every palette has 16 colors. In 8bpp, the palettes are combined into one.
+
+The encoding of the color is in the header with two possible values:
+
+- 0: BGR555 encoding
+- 1: ABGR1555 encoding
+
+In the case of DSIG inside of a DSTX with type 4 (komas), the DSIG always 
+use ABGR1555 color encoding, even when the DSIG header says otherwise. This 
+may be related to the DSTX header value at 0xA always set to 1 in this case.
 
 The game finds the first and last non-null color (`0x0000` for black) across the
 full block of palettes.
@@ -90,5 +98,3 @@ with the number of segments plus one (the 32-bits of the count).
 
 In the version 2 of DSIG files, there is a 32-bits integer before the pixel data
 which is unknown.
-
-This format uses the color encoding ABGR555 for the palette.

--- a/docs/articles/specs/dsig.md
+++ b/docs/articles/specs/dsig.md
@@ -68,7 +68,7 @@ Every palette has 16 colors. In 8bpp, the palettes are combined into one.
 The encoding of the color is in the header with two possible values:
 
 - 0: BGR555 encoding
-- 1: ABGR1555 encoding
+- 4: ABGR1555 encoding
 
 In the case of DSIG inside of a DSTX with type 4 (komas), the DSIG always 
 use ABGR1555 color encoding, even when the DSIG header says otherwise. This 

--- a/docs/articles/specs/dsig.md
+++ b/docs/articles/specs/dsig.md
@@ -12,17 +12,23 @@ There are two known versions of the formats, each with different variants. This
 games only handles version 2 when the flags value is `0x40`.
 
 | Offset | Type       | Description                                       |
-| ------ | ---------- | ------------------------------------------------- |
+| ------ | ---------- |---------------------------------------------------|
 | 0x00   | char[4]    | Format ID: `DSIG`                                 |
 | 0x04   | byte       | Version: 1 or 2                                   |
 | 0x05   | byte       | Flags                                             |
 | 0x06   | byte       | Number of palettes                                |
-| 0x07   | byte       | Metadata length? (v2 is 4, otherwise 0)           |
+| 0x07   | byte       | Unknown (0 or 4)                                  |
 | 0x08   | ushort     | Image width or block info length / 4 in format 4  |
 | 0x0A   | ushort     | Image height or block data length / 4 in format 4 |
 | 0x0C   | bgr555[][] | Palettes                                          |
-| ...    | uint       | (only v2 with format 4) Metadata?                 |
+| ...    | uint       | Unknown (only v2 with format 4)                   |
 | ...    | byte[]     | Indexed pixels                                    |
+
+> [!NOTE]  
+> If the DSIG contains segments for a DSTX sprite, the _width_ and _height_
+> may contain invalid values. This is because the DSIG won't actually contain
+> any full image, but the DSTX will contain the segment instructions to 
+> reconstruct.
 
 ### Flags
 
@@ -31,11 +37,11 @@ games only handles version 2 when the flags value is `0x40`.
   - 1 -> 8bpp.
 - Bit 4-7: image format.
   - 0 -> not supported.
-  - 1 -> tiled.
+  - 1 -> tiled (tiles of 8x8).
   - 2 -> texture atlas (lineal).
   - 3 -> unknown.
   - 4 -> compressed sprite.
-  - 5 -> unknown.
+  - 5 -> compressed texture atlas (Nitro LZSS with header).
 
 The game provides an implementation for the following combination of flags, and
 gives it a name:

--- a/docs/articles/specs/dsig.md
+++ b/docs/articles/specs/dsig.md
@@ -90,3 +90,5 @@ with the number of segments plus one (the 32-bits of the count).
 
 In the version 2 of DSIG files, there is a 32-bits integer before the pixel data
 which is unknown.
+
+This format uses the color encoding ABGR555 for the palette.

--- a/docs/articles/specs/dstx.md
+++ b/docs/articles/specs/dstx.md
@@ -129,11 +129,11 @@ The **Shape** byte encodes both segment size and flip transformations:
 
 See [the Koma specification](./koma.md) for more details.
 
-| Offset | Type   | Description                                             |
-| ------ | ------ |---------------------------------------------------------|
-| 0x0A   | short  | Unknown, always 1.                                      |
-| 0x0C   | uint[] | Sprite data                                             |
-| ...    | byte[] | Uknown area                                             |
+| Offset | Type   | Description                                            |
+| ------ |--------|--------------------------------------------------------|
+| 0x0A   | ushort | Flags? Always 1 for alpha channel in DSIG?             |
+| 0x0C   | uint[] | Sprite data                                            |
+| ...    | byte[] | Uknown area                                            |
 | ...    | DSIG   | Image with palette (weight 8, swizzled 48x48 tile size) |
 
 The sprite data is 4 bytes:

--- a/docs/articles/specs/resources/dsig.hexpat
+++ b/docs/articles/specs/resources/dsig.hexpat
@@ -28,13 +28,12 @@ struct Dsig {
     u8 version;
     DsigFlags flags;
     u8 paletteCount;
+    u8 colorEncoding; // 0: BGR555, 4: ABGR555
 
     if (flags.format == 4) {
-        u8 metadataLength; // tbc
         u16 blockInfoLength; // divided by 4
         u16 blockDataLength; // divided by 4
     } else {
-        u8 reserved;
         u16 width;
         u16 height;
     }

--- a/src/JUS.CLI/JUS/BatchCommands.cs
+++ b/src/JUS.CLI/JUS/BatchCommands.cs
@@ -97,7 +97,7 @@ namespace JUS.CLI.JUS
 
                                 Dig originalImage = dtx3.Children["image"].GetFormatAs<Dig>();
 
-                                if (originalImage.Swizzling == DigSwizzling.Linear) {
+                                if (originalImage.DataFormat == DigDataFormat.Linear) {
                                     BinaryFormat image = new IndexedImage2BinaryPng(originalImage).Convert(originalImage);
                                     image.Stream.WriteTo(Path.Combine(baseOutputPath, $"{originalAlarName}-{child.Name}-tx.png"));
                                 }

--- a/src/JUS.CLI/JUS/Graphics/DtxCommands.cs
+++ b/src/JUS.CLI/JUS/Graphics/DtxCommands.cs
@@ -22,7 +22,6 @@ using JUS.Tool.Graphics;
 using JUS.Tool.Graphics.Converters;
 using JUS.Tool.Utils;
 using Texim.Formats.ImageSharp.Images;
-using Texim.Games.Nitro.Sprites;
 using Texim.Images;
 using Texim.Images.Quantization;
 using Texim.Palettes;
@@ -80,7 +79,7 @@ namespace JUS.CLI.JUS.Graphics
 
             Dig originalImage = dtx3.Children["image"].GetFormatAs<Dig>();
 
-            if (originalImage.Swizzling != DigSwizzling.Linear) {
+            if (originalImage.DataFormat != DigDataFormat.Linear) {
                 throw new FormatException("Image is not DTX03TX");
             }
 
@@ -350,7 +349,7 @@ namespace JUS.CLI.JUS.Graphics
                 Pixels = tiledPixels.ToArray(),
                 Width = 8,
                 Height = tiledPixels.Length / 8,
-                Swizzling = DigSwizzling.Linear,
+                DataFormat = DigDataFormat.Linear,
             }.InsertTransparentTile();
 
             dtx4.Children["image"].ChangeFormat(updatedImage);

--- a/src/JUS.CLI/JUS/Graphics/DtxCommands.cs
+++ b/src/JUS.CLI/JUS/Graphics/DtxCommands.cs
@@ -341,7 +341,11 @@ namespace JUS.CLI.JUS.Graphics
                 segmentedImage.AddRange(segmentImage.Pixels);
             }
 
-            // Linear image to Tiled image (how the DTX stores them)
+            // We do swizzling now, instead of waiting the Dig2Binary converter to do it because the game
+            // does swizzling with width 48 (segments width), but the converter will do it with the image width 8.
+            // Providing the swizzled pixels now, and letting Dig2Binary do swizzling again it's not an issue because
+            // swizzling with width 8 (and tile size 8x8) does nothing. So when the Dig2Binary converter swizzles a second time
+            // with the image width of 8, it will get the same pixels as give it now swizzled at 48.
             IndexedPixel[] tiledPixels = new TileSwizzling<IndexedPixel>(48).Swizzle(segmentedImage);
 
             // Update image with the new changes
@@ -349,7 +353,6 @@ namespace JUS.CLI.JUS.Graphics
                 Pixels = tiledPixels.ToArray(),
                 Width = 8,
                 Height = tiledPixels.Length / 8,
-                DataFormat = DigDataFormat.Linear,
             }.InsertTransparentTile();
 
             dtx4.Children["image"].ChangeFormat(updatedImage);

--- a/src/JUS.CLI/JUS/Rom/SpriteDtx3TxImageFile.cs
+++ b/src/JUS.CLI/JUS/Rom/SpriteDtx3TxImageFile.cs
@@ -147,7 +147,7 @@ namespace JUS.CLI.JUS.Rom
 
             Dig originalImage = workingDtx.Children["image"].GetFormatAs<Dig>();
 
-            if (originalImage.Swizzling != DigSwizzling.Linear) {
+            if (originalImage.DataFormat != DigDataFormat.Linear) {
                 throw new FormatException($"{dtxName} is not a Dtx3Tx.");
             }
 

--- a/src/JUS.Tests/Containers/AlarTests.cs
+++ b/src/JUS.Tests/Containers/AlarTests.cs
@@ -13,7 +13,7 @@ public class AlarTests
 {
     private static readonly Lazy<NitroRom> Root = new(TestDataBase.ReadSoftware);
 
-    public static IEnumerable<TestCaseData> GetLevel1Paths()
+    private static IEnumerable<TestCaseData> GetLevel1Paths()
     {
         if (!File.Exists(TestDataBase.SoftwareNitroRomPath)) {
             return [];
@@ -21,10 +21,10 @@ public class AlarTests
 
         return Navigator.IterateNodes(Root.Value.Data, NavigationMode.DepthFirst)
             .Where(n => !n.IsContainer && n.Name.EndsWith(".aar"))
-            .Select(n => new TestCaseData(n.Path));
+            .Select(n => new TestCaseData(n).SetArgDisplayNames(n.Path));
     }
 
-    public static IEnumerable<TestCaseData> GetLevel2Paths()
+    private static IEnumerable<TestCaseData> GetLevel2Paths()
     {
         if (!File.Exists(TestDataBase.SoftwareNitroRomPath)) {
             return [];
@@ -36,36 +36,15 @@ public class AlarTests
                 NodeContainerFormat alar = new Binary2Alar().Convert(n.GetFormatAs<IBinary>());
                 return Navigator.IterateNodes(alar.Root, NavigationMode.DepthFirst)
                     .Where(c => !c.IsContainer && c.Name.EndsWith(".aar"))
-                    .Select(c => new TestCaseData(n.Path, c.Path));
+                    .Select(c => new TestCaseData(c).SetArgDisplayNames($"{n.Path}{c.Path}"));
             });
     }
 
     [TestCaseSource(nameof(GetLevel1Paths))]
-    public void GenerateIdenticalContainerLevel1(string containerPath)
-    {
-        TestDataBase.IgnoreIfFileDoesNotExist(TestDataBase.SoftwareNitroRomPath);
-
-        IBinary? original = Navigator.GetNode(Root.Value.Data, containerPath)?.GetFormatAs<IBinary>();
-        Assert.That(original, Is.Not.Null);
-
-        AssertGeneratesIdentical(original);
-    }
-
     [TestCaseSource(nameof(GetLevel2Paths))]
-    public void GenerateIdenticalContainerLevel2(string parentContainerPath, string childContainerPath)
+    public void GenerateIdenticalContainers(Node container)
     {
-        TestDataBase.IgnoreIfFileDoesNotExist(TestDataBase.SoftwareNitroRomPath);
-
-        IBinary? parentBinary = Navigator.GetNode(Root.Value.Data, parentContainerPath)
-            ?.GetFormatAs<IBinary>();
-        Assert.That(parentBinary, Is.Not.Null);
-
-        NodeContainerFormat parent = new Binary2Alar().Convert(parentBinary);
-
-        IBinary? original = Navigator.GetNode(parent.Root, childContainerPath)
-            ?.GetFormatAs<IBinary>();
-        Assert.That(original, Is.Not.Null);
-
+        IBinary original = container.GetFormatAs<IBinary>();
         AssertGeneratesIdentical(original);
     }
 

--- a/src/JUS.Tests/Graphics/BinaryDig2BitmapTests.cs
+++ b/src/JUS.Tests/Graphics/BinaryDig2BitmapTests.cs
@@ -1,0 +1,40 @@
+﻿using JUS.Tool.Graphics.Converters;
+using NUnit.Framework;
+using Yarhl.FileSystem;
+using Yarhl.IO;
+
+namespace JUS.Tests.Graphics;
+
+[TestFixture]
+public class BinaryDig2BitmapTests
+{
+    private static IEnumerable<TestCaseData> GetFiles()
+    {
+        string basePath = Path.Combine(TestDataBase.RootFromOutputPath, "Graphics");
+        string listPath = Path.Combine(basePath, "dig.txt");
+        return TestDataBase.ReadTestListFile(listPath)
+            .Select(line => line.Split(','))
+            .Select(data => new TestCaseData(
+                    Path.Combine(basePath, data[0]),
+                    Path.Combine(basePath, data[1]),
+                    Path.Combine(basePath, data[2]))
+                .SetName($"({data[0]}, {data[1]}, {data[2]})"));
+    }
+
+    [TestCaseSource(nameof(GetFiles))]
+    public void DeserializeAndCheckFileHash(string infoPath, string digPath, string atmPath)
+    {
+        TestDataBase.IgnoreIfFileDoesNotExist(infoPath);
+        TestDataBase.IgnoreIfFileDoesNotExist(digPath);
+        TestDataBase.IgnoreIfFileDoesNotExist(atmPath);
+
+        var info = BinaryInfo.FromYaml(infoPath);
+
+        using Node mapsNode = NodeFactory.FromFile(atmPath, FileOpenMode.Read);
+
+        using Node pixelsPaletteNode = NodeFactory.FromFile(digPath, FileOpenMode.Read)
+            .TransformWith(new BinaryDig2Bitmap(mapsNode));
+
+        pixelsPaletteNode.Stream.Should().MatchInfo(info);
+    }
+}

--- a/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
+++ b/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
@@ -76,7 +76,7 @@ public class Dig2BinaryTests
         }
 
         // exclude 0x83 which has the dig in another file
-        var reader = new DataReader(dstx.Stream);
+        var reader = new DataReader(dstxBinary.Stream);
         reader.Stream.Position = 5;
         byte dstxType = reader.ReadByte();
         bool hasDsig = (dstxType & 0x80) == 0;

--- a/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
+++ b/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
@@ -66,15 +66,30 @@ public class Dig2BinaryTests
         }
 
         // exclude 0x83 which has the dig in another file
-        dstx.Stream.Position = 5;
-        bool hasDsig = (dstx.Stream.ReadByte() & 0x80) == 0;
+        var reader = new DataReader(dstx.Stream);
+        reader.Stream.Position = 5;
+        byte dstxType = reader.ReadByte();
+        bool hasDsig = (dstxType & 0x80) == 0;
         if (!hasDsig) {
             Assert.Pass("DSIG in separate file");
         }
 
+        bool supportAlpha = false;
+        if (dstxType is 4) {
+            reader.Stream.Position = 0x0A;
+            supportAlpha = reader.ReadUInt16() == 1;
+        }
+
         using BinaryFormat originalDsig = ExtractDsigData(dstxBinary.Stream);
-        Dig dig = new Binary2Dig().Convert(originalDsig);
+        Dig dig = new Binary2Dig(supportAlpha).Convert(originalDsig);
         BinaryFormat generatedStream = new Dig2Binary().Convert(dig);
+
+        if (dig.DataFormat is DigDataFormat.CompressedBlocks or DigDataFormat.CompressedImage) {
+            // Because our LZSS compressor doesn't generate the same input, we can't compare it.
+            Assert.That(generatedStream.Stream.Length, Is.LessThanOrEqualTo(originalDsig.Stream.Length));
+            AssertEquivalentPixels(dig, generatedStream);
+            return;
+        }
 
         bool areIdentical = generatedStream.Stream.Compare(originalDsig.Stream);
 #if DEBUG
@@ -94,5 +109,12 @@ public class Dig2BinaryTests
             ushort dsigOffset = reader.ReadUInt16();
             return new BinaryFormat(dstx.Slice(dsigOffset));
         }
+    }
+
+    private static void AssertEquivalentPixels(Dig original, BinaryFormat generated)
+    {
+        Dig generatedDig = new Binary2Dig().Convert(generated);
+
+        Assert.That(generatedDig, Is.EqualTo(original).UsingPropertiesComparer());
     }
 }

--- a/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
+++ b/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
@@ -1,0 +1,98 @@
+﻿using JUS.Tool.Graphics;
+using JUS.Tool.Graphics.Converters;
+using JUS.Tool.Utils;
+using NUnit.Framework;
+using SceneGate.Ekona.Containers.Rom;
+using Yarhl.FileSystem;
+using Yarhl.IO;
+
+namespace JUS.Tests.Graphics;
+
+[TestFixture]
+public class Dig2BinaryTests
+{
+    private static IEnumerable<TestCaseData> GetDsigNodes()
+    {
+        NitroRom? unpackedRoot = TestDataBase.UnpackedRoot.Value;
+        if (unpackedRoot is null) {
+            return [];
+        }
+
+        return Navigator.IterateNodes(unpackedRoot.Data, NavigationMode.DepthFirst)
+            .Where(n => n.Extension == ".dig")
+            .Select(n => new TestCaseData(n).SetArgDisplayNames(n.Path));
+    }
+
+    private static IEnumerable<TestCaseData> GetDstxNodes()
+    {
+        NitroRom? unpackedRoot = TestDataBase.UnpackedRoot.Value;
+        if (unpackedRoot is null) {
+            return [];
+        }
+
+        return Navigator.IterateNodes(unpackedRoot.Data, NavigationMode.DepthFirst)
+            .Where(n => n.Extension == ".dtx")
+            .Select(n => new TestCaseData(n).SetArgDisplayNames(n.Path));
+    }
+
+    [TestCaseSource(nameof(GetDsigNodes))]
+    public void TwoWaysIdenticalDigStream(Node node)
+    {
+        IBinary originalBinary = node.GetFormatAs<IBinary>();
+        if (CompressionUtils.IsCompressed(originalBinary.Stream)) {
+            originalBinary = new LzssDecompression().Convert(originalBinary);
+        }
+
+        Dig dig = new Binary2Dig().Convert(originalBinary);
+        BinaryFormat generatedStream = new Dig2Binary().Convert(dig);
+
+        bool areIdentical = generatedStream.Stream.Compare(originalBinary.Stream);
+#if DEBUG
+        if (!areIdentical) {
+            TestDataBase.WriteFailedData(generatedStream.Stream, $"actual_{node.Name}");
+            TestDataBase.WriteFailedData(originalBinary.Stream, $"expected_{node.Name}");
+        }
+#endif
+
+        Assert.That(areIdentical, Is.True);
+    }
+
+    [TestCaseSource(nameof(GetDstxNodes))]
+    public void TwoWaysIdenticalInsideDstx(Node dstx)
+    {
+        IBinary dstxBinary = dstx.GetFormatAs<IBinary>();
+        if (CompressionUtils.IsCompressed(dstxBinary.Stream)) {
+            dstxBinary = new LzssDecompression().Convert(dstxBinary);
+        }
+
+        // exclude 0x83 which has the dig in another file
+        dstx.Stream.Position = 5;
+        bool hasDsig = (dstx.Stream.ReadByte() & 0x80) == 0;
+        if (!hasDsig) {
+            Assert.Pass("DSIG in separate file");
+        }
+
+        using BinaryFormat originalDsig = ExtractDsigData(dstxBinary.Stream);
+        Dig dig = new Binary2Dig().Convert(originalDsig);
+        BinaryFormat generatedStream = new Dig2Binary().Convert(dig);
+
+        bool areIdentical = generatedStream.Stream.Compare(originalDsig.Stream);
+#if DEBUG
+        if (!areIdentical) {
+            TestDataBase.WriteFailedData(generatedStream.Stream, $"actual_{dstx.Name}");
+            TestDataBase.WriteFailedData(originalDsig.Stream, $"expected_{dstx.Name}");
+        }
+#endif
+
+        Assert.That(areIdentical, Is.True);
+
+        return;
+        static BinaryFormat ExtractDsigData(Stream dstx)
+        {
+            var reader = new DataReader(dstx);
+            reader.Stream.Position = 0x8;
+            ushort dsigOffset = reader.ReadUInt16();
+            return new BinaryFormat(dstx.Slice(dsigOffset));
+        }
+    }
+}

--- a/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
+++ b/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
@@ -9,6 +9,7 @@ using Yarhl.IO;
 namespace JUS.Tests.Graphics;
 
 [TestFixture]
+[Parallelizable(ParallelScope.Children)]
 public class Dig2BinaryTests
 {
     private const int CompressedMargin = 512;
@@ -48,22 +49,21 @@ public class Dig2BinaryTests
         Dig dig = new Binary2Dig().Convert(originalBinary);
         BinaryFormat generatedStream = new Dig2Binary().Convert(dig);
 
-        if (dig.DataFormat is DigDataFormat.CompressedBlocks or DigDataFormat.CompressedImage) {
-            // Because our LZSS compressor doesn't generate the same input, we can't compare it.
-            Assert.That(generatedStream.Stream.Length, Is.LessThanOrEqualTo(originalBinary.Stream.Length + CompressedMargin));
-            AssertEquivalentPixels(dig, generatedStream);
-            return;
-        }
-
-        bool areIdentical = generatedStream.Stream.Compare(originalBinary.Stream);
+        try {
+            if (dig.DataFormat is DigDataFormat.CompressedBlocks or DigDataFormat.CompressedImage) {
+                AssertEquivalentCompressedPixels(originalBinary, dig, generatedStream);
+            } else {
+                Assert.That(
+                    generatedStream.Stream.Compare(originalBinary.Stream),
+                    Is.True,
+                    $"DSIG (v{dig.Version}/{dig.DataFormat}) are not identical");
+            }
+        } catch {
 #if DEBUG
-        if (!areIdentical) {
             TestDataBase.WriteFailedData(generatedStream.Stream, $"actual_{node.Name}");
             TestDataBase.WriteFailedData(originalBinary.Stream, $"expected_{node.Name}");
-        }
 #endif
-
-        Assert.That(areIdentical, Is.True);
+        }
     }
 
     [TestCaseSource(nameof(GetDstxNodes))]
@@ -93,22 +93,21 @@ public class Dig2BinaryTests
         Dig dig = new Binary2Dig(supportAlpha).Convert(originalDsig);
         BinaryFormat generatedStream = new Dig2Binary().Convert(dig);
 
-        if (dig.DataFormat is DigDataFormat.CompressedBlocks or DigDataFormat.CompressedImage) {
-            // Because our LZSS compressor doesn't generate the same input, we can't compare it.
-            Assert.That(generatedStream.Stream.Length, Is.LessThanOrEqualTo(originalDsig.Stream.Length + CompressedMargin));
-            AssertEquivalentPixels(dig, generatedStream);
-            return;
-        }
-
-        bool areIdentical = generatedStream.Stream.Compare(originalDsig.Stream);
+        try {
+            if (dig.DataFormat is DigDataFormat.CompressedBlocks or DigDataFormat.CompressedImage) {
+                AssertEquivalentCompressedPixels(originalDsig, dig, generatedStream);
+            } else {
+                Assert.That(
+                    generatedStream.Stream.Compare(originalDsig.Stream),
+                    Is.True,
+                    $"DSIG (v{dig.Version}/{dig.DataFormat}) are not identical");
+            }
+        } catch {
 #if DEBUG
-        if (!areIdentical) {
             TestDataBase.WriteFailedData(generatedStream.Stream, $"actual_{dstx.Name}");
             TestDataBase.WriteFailedData(originalDsig.Stream, $"expected_{dstx.Name}");
-        }
 #endif
-
-        Assert.That(areIdentical, Is.True);
+        }
 
         return;
         static BinaryFormat ExtractDsigData(Stream dstx)
@@ -120,10 +119,26 @@ public class Dig2BinaryTests
         }
     }
 
-    private static void AssertEquivalentPixels(Dig original, BinaryFormat generated)
+    private static void AssertEquivalentCompressedPixels(IBinary original, Dig dig, BinaryFormat generated)
     {
-        Dig generatedDig = new Binary2Dig().Convert(generated);
+        // We can't compare compressed pixels because LZSS algorithm is different
+        // Assert data before compression except in compressed blocks because the header has the compression length
+        if (dig.DataFormat is DigDataFormat.CompressedImage || generated.Stream.Length == original.Stream.Length) {
+            int pixelsDataOffset = 0xC + (dig.Palettes.Sum(p => p.Colors.Count) * 2);
+            if (dig.Version == 2 && dig.DataFormat is DigDataFormat.CompressedBlocks) {
+                pixelsDataOffset += 4;
+            }
 
-        Assert.That(generatedDig, Is.EqualTo(original).UsingPropertiesComparer());
+            DataStream originalComparable = original.Stream.Slice(0, pixelsDataOffset);
+            DataStream generatedComparable = generated.Stream.Slice(0, pixelsDataOffset);
+            Assert.That(generatedComparable.Compare(originalComparable), Is.True, "Raw data is not equal");
+        }
+
+        // Files should not be bigger as they may cause RAM issues.
+        Assert.That(generated.Stream.Length, Is.LessThanOrEqualTo(original.Stream.Length + CompressedMargin));
+
+        // Deserialize and check we have the same pixels (assuming deserializer is perfect)
+        Dig generatedDig = new Binary2Dig().Convert(generated);
+        Assert.That(generatedDig, Is.EqualTo(dig).UsingPropertiesComparer());
     }
 }

--- a/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
+++ b/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
@@ -63,6 +63,7 @@ public class Dig2BinaryTests
             TestDataBase.WriteFailedData(generatedStream.Stream, $"actual_{node.Name}");
             TestDataBase.WriteFailedData(originalBinary.Stream, $"expected_{node.Name}");
 #endif
+            throw;
         }
     }
 
@@ -107,6 +108,7 @@ public class Dig2BinaryTests
             TestDataBase.WriteFailedData(generatedStream.Stream, $"actual_{dstx.Name}");
             TestDataBase.WriteFailedData(originalDsig.Stream, $"expected_{dstx.Name}");
 #endif
+            throw;
         }
 
         return;

--- a/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
+++ b/src/JUS.Tests/Graphics/Dig2BinaryTests.cs
@@ -11,6 +11,8 @@ namespace JUS.Tests.Graphics;
 [TestFixture]
 public class Dig2BinaryTests
 {
+    private const int CompressedMargin = 512;
+
     private static IEnumerable<TestCaseData> GetDsigNodes()
     {
         NitroRom? unpackedRoot = TestDataBase.UnpackedRoot.Value;
@@ -45,6 +47,13 @@ public class Dig2BinaryTests
 
         Dig dig = new Binary2Dig().Convert(originalBinary);
         BinaryFormat generatedStream = new Dig2Binary().Convert(dig);
+
+        if (dig.DataFormat is DigDataFormat.CompressedBlocks or DigDataFormat.CompressedImage) {
+            // Because our LZSS compressor doesn't generate the same input, we can't compare it.
+            Assert.That(generatedStream.Stream.Length, Is.LessThanOrEqualTo(originalBinary.Stream.Length + CompressedMargin));
+            AssertEquivalentPixels(dig, generatedStream);
+            return;
+        }
 
         bool areIdentical = generatedStream.Stream.Compare(originalBinary.Stream);
 #if DEBUG
@@ -86,7 +95,7 @@ public class Dig2BinaryTests
 
         if (dig.DataFormat is DigDataFormat.CompressedBlocks or DigDataFormat.CompressedImage) {
             // Because our LZSS compressor doesn't generate the same input, we can't compare it.
-            Assert.That(generatedStream.Stream.Length, Is.LessThanOrEqualTo(originalDsig.Stream.Length));
+            Assert.That(generatedStream.Stream.Length, Is.LessThanOrEqualTo(originalDsig.Stream.Length + CompressedMargin));
             AssertEquivalentPixels(dig, generatedStream);
             return;
         }

--- a/src/JUS.Tests/Graphics/DtxTests.cs
+++ b/src/JUS.Tests/Graphics/DtxTests.cs
@@ -227,7 +227,7 @@ namespace JUS.Tests.Graphics
                 Pixels = tiledPixels.ToArray(),
                 Width = 8,
                 Height = tiledPixels.Length / 8,
-                Swizzling = DigSwizzling.Linear,
+                DataFormat = DigDataFormat.Linear,
             }.InsertTransparentTile();
 
             dtx4.Children["image"].ChangeFormat(updatedImage);

--- a/src/JUS.Tests/Graphics/DtxTests.cs
+++ b/src/JUS.Tests/Graphics/DtxTests.cs
@@ -218,6 +218,7 @@ namespace JUS.Tests.Graphics
             }
 
             // Linear image to Tiled image (how the DTX stores them)
+            // See the DtxCommand for information about why we do swizzling here.
             IndexedPixel[] tiledPixels = new TileSwizzling<IndexedPixel>(48).Swizzle(segmentedImage);
 
             // Update image with the new changes

--- a/src/JUS.Tests/Graphics/DtxTests.cs
+++ b/src/JUS.Tests/Graphics/DtxTests.cs
@@ -24,10 +24,8 @@ using JUS.Tool.Graphics.Converters;
 using JUS.Tool.Utils;
 using NUnit.Framework;
 using Texim.Formats.ImageSharp.Images;
-using Texim.Games.Nitro.Sprites;
 using Texim.Images;
 using Texim.Images.Quantization;
-using Texim.Palettes;
 using Texim.Pixels;
 using Texim.Sprites;
 using Yarhl.FileSystem;
@@ -227,7 +225,6 @@ namespace JUS.Tests.Graphics
                 Pixels = tiledPixels.ToArray(),
                 Width = 8,
                 Height = tiledPixels.Length / 8,
-                DataFormat = DigDataFormat.Linear,
             }.InsertTransparentTile();
 
             dtx4.Children["image"].ChangeFormat(updatedImage);
@@ -237,10 +234,13 @@ namespace JUS.Tests.Graphics
 
             // Compare
             var originalStream = new DataStream(originalDtx.Stream, 0, originalDtx.Stream.Length);
-            generatedStream.Length.Should().Be(originalStream.Length);
-            originalStream.WriteTo("original.dtx");
-            generatedStream.WriteTo("generated.dtx");
-            generatedStream.Compare(originalStream).Should().BeTrue();
+            bool areIdentical = generatedStream.Compare(originalStream);
+            if (!areIdentical) {
+                TestDataBase.WriteFailedData(originalStream, "original.dtx");
+                TestDataBase.WriteFailedData(generatedStream, "generated.dtx");
+            }
+
+            Assert.That(areIdentical, Is.True);
         }
 
         [TestCaseSource(nameof(GetDtx3Files))]

--- a/src/JUS.Tests/Graphics/Png2DigAtmTests.cs
+++ b/src/JUS.Tests/Graphics/Png2DigAtmTests.cs
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using FluentAssertions;
-using JUS.Tool.Containers.Converters;
 using JUS.Tool.Graphics;
 using JUS.Tool.Graphics.Converters;
 using JUS.Tool.Utils;
@@ -30,26 +29,26 @@ using Yarhl.IO;
 namespace JUS.Tests.Graphics
 {
     [TestFixture]
-    public class DigTests
+    public class Png2DigAtmTests
     {
-        private static readonly Lazy<Node> TopMenuContainer = new(UnpackTopMenuContainer);
+        private static readonly Lazy<Node?> TopMenuContainer = new(UnpackTopMenuContainer);
 
-        private static Node UnpackTopMenuContainer()
+        private static Node? UnpackTopMenuContainer()
         {
-            return TestDataBase.ReadSoftware()
-                .Data
+            return TestDataBase.UnpackedRoot.Value
+                ?.Data
                 .Children["topmenu"]
-                .Children["topmenu.aar"]
-                .TransformWith(new Binary2Alar());
+                .Children["topmenu.aar"];
         }
 
         private static IEnumerable<TestCaseData> GetDigNodes()
         {
-            if (!File.Exists(TestDataBase.SoftwareNitroRomPath)) {
+            Node? topContainer = TopMenuContainer.Value;
+            if (topContainer is null) {
                 return [];
             }
 
-            return Navigator.IterateNodes(TopMenuContainer.Value, NavigationMode.DepthFirst)
+            return Navigator.IterateNodes(topContainer, NavigationMode.DepthFirst)
                 .Where(n => n.Name == "top_bg01.dig")
                 .Select(n => new TestCaseData(n).SetArgDisplayNames(n.Path));
         }
@@ -138,52 +137,6 @@ namespace JUS.Tests.Graphics
             );
 
             _ = blackPalettes.Should().BeEmpty();
-        }
-
-        public static IEnumerable<TestCaseData> GetFiles()
-        {
-            string basePath = Path.Combine(TestDataBase.RootFromOutputPath, "Graphics");
-            string listPath = Path.Combine(basePath, "dig.txt");
-            return TestDataBase.ReadTestListFile(listPath)
-                .Select(line => line.Split(','))
-                .Select(data => new TestCaseData(
-                    Path.Combine(basePath, data[0]),
-                    Path.Combine(basePath, data[1]),
-                    Path.Combine(basePath, data[2]))
-                    .SetName($"({data[0]}, {data[1]}, {data[2]})"));
-        }
-
-        [TestCaseSource(nameof(GetFiles))]
-        public void DeserializeAndCheckFileHash(string infoPath, string digPath, string atmPath)
-        {
-            TestDataBase.IgnoreIfFileDoesNotExist(infoPath);
-            TestDataBase.IgnoreIfFileDoesNotExist(digPath);
-            TestDataBase.IgnoreIfFileDoesNotExist(atmPath);
-
-            var info = BinaryInfo.FromYaml(infoPath);
-
-            using Node mapsNode = NodeFactory.FromFile(atmPath, FileOpenMode.Read);
-
-            using Node pixelsPaletteNode = NodeFactory.FromFile(digPath, FileOpenMode.Read)
-                .TransformWith(new BinaryDig2Bitmap(mapsNode));
-
-            pixelsPaletteNode.Stream.Should().MatchInfo(info);
-        }
-
-        [TestCaseSource(nameof(GetFiles))]
-        public void TwoWaysIdenticalDigStream(string infoPath, string digPath, string atmPath)
-        {
-            Assert.Ignore("Imported Dig are smaller, we neet to test with PNGs instead");
-            TestDataBase.IgnoreIfFileDoesNotExist(digPath);
-
-            using Node node = NodeFactory.FromFile(digPath, FileOpenMode.Read);
-
-            Dig dig = node.GetFormatAs<IBinary>().ConvertWith(new Binary2Dig());
-            BinaryFormat generatedStream = dig.ConvertWith(new Dig2Binary());
-
-            var originalStream = new DataStream(node.Stream, 0, node.Stream.Length);
-            generatedStream.Stream.Length.Should().Be(originalStream.Length);
-            generatedStream.Stream.Compare(originalStream).Should().BeTrue();
         }
     }
 }

--- a/src/JUS.Tests/TestDataBase.cs
+++ b/src/JUS.Tests/TestDataBase.cs
@@ -101,10 +101,10 @@ namespace JUS.Tests
                 .Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith('#'));
         }
 
-        public static void WriteFailedData(Stream? stream, string name)
+        public static void WriteFailedData(Stream stream, string name)
         {
             string path = Path.Combine(RootTestFailedPath, name);
-            stream?.WriteTo(path);
+            stream.WriteTo(path);
         }
 
     }

--- a/src/JUS.Tool/Discovery/SupportedSoftware.cs
+++ b/src/JUS.Tool/Discovery/SupportedSoftware.cs
@@ -31,6 +31,8 @@ public static class SupportedSoftware
         return info is null ? null : GameCode == info.GameCode;
 
         static ProgramInfo? GetProgramInfo(Node node) =>
-            node.Children["system"]?.Children["info"]?.Format as ProgramInfo;
+            node.Children.GetOrDefault("system")
+                ?.Children.GetOrDefault("info")
+                ?.Format as ProgramInfo;
     }
 }

--- a/src/JUS.Tool/Framework/Abgr555.cs
+++ b/src/JUS.Tool/Framework/Abgr555.cs
@@ -4,7 +4,7 @@ using Texim.Colors;
 namespace JUS.Tool.Framework;
 
 /// <summary>
-/// BGR555 color encoding: 5 bits per channel in blue, green, red order, with
+/// ABGR555 color encoding: 5 bits per channel in blue, green, red order, with
 /// one bit for alpha chanel. Encoded in little-endian format.
 /// </summary>
 public class Abgr555Encoding : LinealByteColorEncoding

--- a/src/JUS.Tool/Framework/Abgr555.cs
+++ b/src/JUS.Tool/Framework/Abgr555.cs
@@ -1,0 +1,57 @@
+﻿using System.Buffers.Binary;
+using Texim.Colors;
+
+namespace JUS.Tool.Framework;
+
+/// <summary>
+/// BGR555 color encoding: 5 bits per channel in blue, green, red order, with
+/// one bit for alpha chanel. Encoded in little-endian format.
+/// </summary>
+public class Abgr555Encoding : LinealByteColorEncoding
+{
+    /// <summary>
+    /// Gets a singleton instance of this class.
+    /// </summary>
+    public static Abgr555Encoding Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public override int BytesPerColor => 2;
+
+    /// <summary>
+    /// Decodes a color from an unsigned integer of 16-bits.
+    /// </summary>
+    /// <param name="value">The binary encoded color.</param>
+    /// <returns>The decoded color.</returns>
+    public static Rgb FromUInt16(ushort value)
+    {
+        Rgb bgr555 = Bgr555Encoding.FromUInt16(value);
+        byte alpha = (byte)((value >> 15) == 0 ? 0 : 255);
+        return new Rgb(bgr555, alpha);
+    }
+
+    /// <summary>
+    /// Encodes a color as an unsigned integer of 16-bits.
+    /// </summary>
+    /// <param name="color">The color to binary encode.</param>
+    /// <returns>The binary encoded color.</returns>
+    public static ushort ToUInt16(Rgb color)
+    {
+        ushort encoded = Bgr555Encoding.ToUInt16(color);
+        encoded |= (ushort)((color.Alpha == 0 ? 0 : 1) << 15);
+        return encoded;
+    }
+
+    /// <inheritdoc />
+    protected override Rgb ReadColor(ReadOnlySpan<byte> data)
+    {
+        ushort value = BinaryPrimitives.ReadUInt16LittleEndian(data);
+        return FromUInt16(value);
+    }
+
+    /// <inheritdoc />
+    protected override void WriteColor(Span<byte> output, Rgb color)
+    {
+        ushort value = ToUInt16(color);
+        BinaryPrimitives.WriteUInt16LittleEndian(output, value);
+    }
+}

--- a/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
+++ b/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
@@ -47,7 +47,7 @@ namespace JUS.Tool.Graphics.Converters
             source.Stream.Position = 0;
 
             // Header
-            if (reader.ReadString(4) != Dig.STAMP) {
+            if (reader.ReadString(4) != Dig.Stamp) {
                 throw new FormatException("Invalid stamp");
             }
 
@@ -56,7 +56,7 @@ namespace JUS.Tool.Graphics.Converters
             var bpp = (DigBpp)(flags & 0x0F);
             var dataFormat = (DigDataFormat)(flags >> 4);
             byte paletteCount = reader.ReadByte();
-            byte metadataLength = reader.ReadByte();
+            byte unk07 = reader.ReadByte();
             ushort field08 = reader.ReadUInt16();
             ushort field0A = reader.ReadUInt16();
 
@@ -109,9 +109,9 @@ namespace JUS.Tool.Graphics.Converters
                 palettes.Add(new Palette(reader.ReadColors<Abgr555Encoding>(colorsPerPalette)));
             }
 
-            byte[] metadata = [];
+            uint unkBlockValue = 0;
             if (version != 1 && dataFormat is DigDataFormat.CompressedBlocks) {
-                metadata = reader.ReadBytes(metadataLength);
+                unkBlockValue = reader.ReadUInt32();
             }
 
             byte[][] compressedSegments = [];
@@ -143,9 +143,10 @@ namespace JUS.Tool.Graphics.Converters
                 Width = width,
                 Height = height,
                 OriginalSize = originalSize,
+                UnknownValue7 = unk07,
                 Pixels = pixels,
                 Palettes = palettes,
-                Metadata = metadata,
+                UnknownBlockValue = unkBlockValue,
                 CompressedSegments = compressedSegments,
             };
             return dig;

--- a/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
+++ b/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
@@ -92,35 +92,20 @@ namespace JUS.Tool.Graphics.Converters
 
             (IndexedPixel[] pixels, DigBlockInfo[] blocks) = ReadImageData(source.Stream, bpp, dataFormat);
 
-            // In the case of compressed blocks, there isn't the concept of width. We generate an always valid one.
-            int width, height;
-            if (dataFormat == DigDataFormat.CompressedBlocks) {
-                width = 8;
-                height = pixels.Length / width;
-            } else {
-                width = field08;
-                height = field0A;
-            }
-
-            // DSIG inside DTX may have width and height values that doesn't represent the amount of pixels.
-            // These images do not really have a size, as they have segments to reconstruct a different image.
-            // We calculate a valid size for them based on a minimal width (tile width).
-            var originalSize = new Size(width, height);
-            if (dataFormat != DigDataFormat.CompressedBlocks && (width * height) != pixels.Length) {
-                width = 8;
-                height = pixels.Length / width;
-            }
+            (bool validSize, Size imageSize) = GetValidImageSize(field08, field0A, dataFormat, pixels.Length);
+            Size originalSize = dataFormat is DigDataFormat.CompressedBlocks ? Size.Empty : new Size(field08, field0A);
 
             if (dataFormat is DigDataFormat.Tiled) {
-                pixels = new TileSwizzling<IndexedPixel>(width).Unswizzle(pixels);
+                pixels = new TileSwizzling<IndexedPixel>(imageSize.Width).Unswizzle(pixels);
             }
 
             var dig = new Dig {
                 Version = version,
                 Bpp = bpp,
                 DataFormat = dataFormat,
-                Width = width,
-                Height = height,
+                Width = imageSize.Width,
+                Height = imageSize.Height,
+                HasValidSize = validSize,
                 OriginalSize = originalSize,
                 FormatColorEncoding = colorFormat,
                 ActualColorEncodingFormat = actualColorFormat,
@@ -132,16 +117,34 @@ namespace JUS.Tool.Graphics.Converters
             return dig;
         }
 
+        private static (bool, Size) GetValidImageSize(ushort field08, ushort field0A, DigDataFormat dataFormat, int pixelCount)
+        {
+            // In the case of compressed blocks, there isn't the concept of width. We generate an always valid one.
+            if (dataFormat == DigDataFormat.CompressedBlocks) {
+                return (true, new Size(8, pixelCount / 8));
+            }
+
+            int width = field08;
+            int height = field0A;
+            bool validSize = (width * height) == pixelCount;
+
+            // DSIG inside DTX may have width and height values that doesn't represent the amount of pixels.
+            // These images do not really have a size, as they have segments to reconstruct a different image.
+            // We calculate a valid size for them based on a minimal width (tile width).
+            if (!validSize) {
+                width = 8;
+                height = pixelCount / width;
+            }
+
+            return (validSize, new Size(width, height));
+        }
+
         private static Collection<IPalette> ReadPalettes(DataReader reader, int paletteCount, DigColorFormat colorFormat, DigBpp bpp)
         {
             // Palettes have always 16 colors per palette, but in 8bpp they are combined into a single big palette
             int colorsPerPalette = bpp == DigBpp.Bpp8 ? paletteCount * 16 : 16;
             int actualPaletteCount = bpp == DigBpp.Bpp8 ? 1 : paletteCount;
-            IColorEncoding colorEncoding = colorFormat switch {
-                DigColorFormat.Bgr555 => Bgr555Encoding.Instance,
-                DigColorFormat.Abgr555 => Abgr555Encoding.Instance,
-                _ => throw new FormatException($"Unknown color format: {colorFormat}"),
-            };
+            IColorEncoding colorEncoding = colorFormat.GetColorEncoding();
 
             var palettes = new Collection<IPalette>();
             for (int i = 0; i < actualPaletteCount; i++) {
@@ -155,24 +158,24 @@ namespace JUS.Tool.Graphics.Converters
         private static (IndexedPixel[], DigBlockInfo[]) ReadImageData(Stream stream, DigBpp bpp, DigDataFormat format)
         {
             if (format is DigDataFormat.CompressedImage) {
-                // Decompress full block, and read as lineal.
+                // Decompress full block.
                 using Stream compressed = stream.Slice(stream.Position);
                 using Stream decompressed = new LzssDecoder().Convert(compressed);
                 decompressed.Position = 0;
-                return ReadImageData(decompressed, bpp, DigDataFormat.Linear);
+                return (ReadPixels(decompressed, bpp), []);
             }
 
             if (format is DigDataFormat.CompressedBlocks) {
-                // Read each block, decompress them, and read as lineal.
-                byte[][] compressedSegments = ReadCompressedBlocks(stream);
+                // Read each block and decompress them.
+                IndexedPixel[][] pixelBlocks = ReadCompressedBlocks(stream, bpp);
 
+                // Join every block into a single pixel array, but keep its start pixel and length
+                // so we can recreate the same blocks when writing.
                 List<IndexedPixel> mergedPixels = [];
                 List<DigBlockInfo> blocks = [];
-                for (int i = 0; i < compressedSegments.Length; i++) {
-                    using var blockData = new MemoryStream(compressedSegments[i]);
-                    (IndexedPixel[] blockPixels, _) = ReadImageData(blockData, bpp, DigDataFormat.CompressedImage);
-                    blocks.Add(new DigBlockInfo(i, mergedPixels.Count, blockPixels.Length));
-                    mergedPixels.AddRange(blockPixels);
+                for (int i = 0; i < pixelBlocks.Length; i++) {
+                    blocks.Add(new DigBlockInfo(i, mergedPixels.Count, pixelBlocks[i].Length));
+                    mergedPixels.AddRange(pixelBlocks[i]);
                 }
 
                 return (mergedPixels.ToArray(), blocks.ToArray());
@@ -192,24 +195,28 @@ namespace JUS.Tool.Graphics.Converters
             return bpp.GetPixelEncoding().Decode(data);
         }
 
-        private static byte[][] ReadCompressedBlocks(Stream stream)
+        private static IndexedPixel[][] ReadCompressedBlocks(Stream stream, DigBpp bpp)
         {
             var reader = new DataReader(stream);
             long basePosition = reader.Stream.Position;
             int count = reader.ReadInt32();
-            byte[][] compressedBlocks = new byte[count][];
 
+            IIndexedPixelEncoding pixelEncoding = bpp.GetPixelEncoding();
+            var blocks = new IndexedPixel[count][];
             for (int i = 0; i < count; i++) {
                 ushort encodedOffset = reader.ReadUInt16();
+                long blockPosition = basePosition + (encodedOffset * 4);
                 ushort length = reader.ReadUInt16();
 
-                long blockPosition = basePosition + (encodedOffset * 4);
-                using (reader.Stream.EnterWithPosition(blockPosition)) {
-                    compressedBlocks[i] = reader.ReadBytes(length);
-                }
+                using DataStream compressed = reader.Stream.Slice(blockPosition, length);
+                using Stream decompressed = new LzssDecoder().Convert(compressed);
+
+                decompressed.Position = 0;
+                byte[] decompressedData = decompressed.ReadBytes((int)decompressed.Length);
+                blocks[i] = pixelEncoding.Decode(decompressedData);
             }
 
-            return compressedBlocks;
+            return blocks;
         }
     }
 }

--- a/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
+++ b/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
@@ -17,6 +17,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
+using System.Collections.ObjectModel;
+using System.Drawing;
+using JUS.Tool.Framework;
 using Texim.Colors;
 using Texim.Palettes;
 using Texim.Pixels;
@@ -37,87 +41,133 @@ namespace JUS.Tool.Graphics.Converters
         /// <returns><see cref="Dig"/>.</returns>
         public Dig Convert(IBinary source)
         {
-            if (source is null) {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ArgumentNullException.ThrowIfNull(source);
 
             var reader = new DataReader(source.Stream);
             source.Stream.Position = 0;
 
+            // Header
             if (reader.ReadString(4) != Dig.STAMP) {
                 throw new FormatException("Invalid stamp");
             }
 
-            byte unknown = reader.ReadByte();
-            byte imageFormat = reader.ReadByte();
-            ushort numPaletteLines = reader.ReadUInt16();
-            int width = reader.ReadUInt16();
-            int height = reader.ReadUInt16();
-            uint pixelsStart = (uint)((numPaletteLines * 0x20) + 0xC);
-            var bpp = (DigBpp)(imageFormat & 0x0F);
-            var swizzling = (DigSwizzling)(imageFormat >> 4);
+            byte version = reader.ReadByte();
+            byte flags = reader.ReadByte();
+            var bpp = (DigBpp)(flags & 0x0F);
+            var dataFormat = (DigDataFormat)(flags >> 4);
+            byte paletteCount = reader.ReadByte();
+            byte metadataLength = reader.ReadByte();
+            ushort field08 = reader.ReadUInt16();
+            ushort field0A = reader.ReadUInt16();
+
+            // Palettes have always 16 colors per palette, but in 8bpp they are combined into a single big palette
+            uint pixelsStart = (uint)((paletteCount * 0x20) + 0xC);
+            int pixelLength = (int)(source.Stream.Length - pixelsStart);
+            int pixelCount = bpp == DigBpp.Bpp4 ? pixelLength * 2 : pixelLength;
+
             IIndexedPixelEncoding pixelEncoding;
             int colorsPerPalette;
-            int numPalettes;
-
+            int actualPaletteCount;
             switch (bpp) {
                 case DigBpp.Bpp4:
                     pixelEncoding = Indexed4BppEncoding.Instance;
                     colorsPerPalette = 16;
-                    numPalettes = numPaletteLines;
+                    actualPaletteCount = paletteCount;
                     break;
                 case DigBpp.Bpp8:
                     pixelEncoding = Indexed8BppEncoding.Instance;
-                    colorsPerPalette = 256;
-                    numPalettes = ((numPaletteLines - 1) / 16) + 1;
+                    colorsPerPalette = paletteCount * 16;
+                    actualPaletteCount = 1;
                     break;
                 default:
-                    throw new FormatException("Invalid bpp");
+                    throw new FormatException($"Invalid bpp: {bpp}");
             }
 
-            // Some tiled digs have fake size params
-            if (swizzling == DigSwizzling.Tiled) {
+            // In the case of compressed blocks, there isn't the concept of width.
+            // We generate an always valid one.
+            int width, height;
+            if (dataFormat == DigDataFormat.CompressedBlocks) {
+                // FUTURE: recalculate by pixel count after decompressing the blocks.
                 width = 8;
-                height = bpp switch {
-                    DigBpp.Bpp4 => (int)(source.Stream.Length - pixelsStart) / 4,
-                    DigBpp.Bpp8 => (int)(source.Stream.Length - pixelsStart) / 8,
-                    _ => throw new FormatException("Invalid bpp"),
-                };
+                height = pixelCount / width;
+            } else {
+                width = field08;
+                height = field0A;
             }
 
-            var palettes = new PaletteCollection();
-
-            for (int i = 0; i < numPalettes; i++) {
-                palettes.Palettes.Add(new Palette(reader.ReadColors<Bgr555Encoding>(colorsPerPalette)));
+            // DSIG inside DTX may have a size larger than the amount of pixels present.
+            // Probably this was the size before DSTX segmentation and compression (or the grid size?).
+            var originalSize = new Size(width, height);
+            if (dataFormat != DigDataFormat.CompressedBlocks && (width * height) > pixelCount) {
+                width = 8;
+                height = pixelCount / width;
             }
 
-            source.Stream.Position = pixelsStart;
+            // The format 4 (compressed block) seems to use the alpha bit
+            var palettes = new Collection<IPalette>();
+            for (int i = 0; i < actualPaletteCount; i++) {
+                palettes.Add(new Palette(reader.ReadColors<Abgr555Encoding>(colorsPerPalette)));
+            }
 
-            IndexedPixel[] pixels = swizzling switch {
-                DigSwizzling.Tiled => new TileSwizzling<IndexedPixel>(width)
-                    .Unswizzle(pixelEncoding.DecodeExactly(source.Stream, width * height)),
+            byte[] metadata = [];
+            if (version != 1 && dataFormat is DigDataFormat.CompressedBlocks) {
+                metadata = reader.ReadBytes(metadataLength);
+            }
 
-                DigSwizzling.Linear => pixelEncoding.DecodeExactly(source.Stream, width * height),
+            byte[][] compressedSegments = [];
+            IndexedPixel[] pixels = [];
+            switch (dataFormat) {
+                case DigDataFormat.Linear:
+                case DigDataFormat.Unknown5:
+                    pixels = pixelEncoding.DecodeExactly(source.Stream, width * height);
+                    break;
 
-                _ => throw new FormatException("Invalid swizzling"),
-            };
+                case DigDataFormat.Tiled:
+                    pixels = pixelEncoding.DecodeExactly(source.Stream, width * height);
+                    pixels = new TileSwizzling<IndexedPixel>(width).Unswizzle(pixels);
+                    break;
+
+                case DigDataFormat.CompressedBlocks:
+                    compressedSegments = ReadCompressedBlocks(reader);
+                    break;
+
+                case DigDataFormat.Unknown3:
+                default:
+                    throw new FormatException($"Invalid data format: {dataFormat}");
+            }
 
             var dig = new Dig {
-                Unknown = unknown,
-                ImageFormat = imageFormat,
-                NumPaletteLines = numPaletteLines,
+                Version = version,
+                Bpp = bpp,
+                DataFormat = dataFormat,
                 Width = width,
                 Height = height,
+                OriginalSize = originalSize,
                 Pixels = pixels,
-                PixelsStart = pixelsStart,
-                Bpp = bpp,
-                Swizzling = swizzling,
+                Palettes = palettes,
+                Metadata = metadata,
+                CompressedSegments = compressedSegments,
             };
-            foreach (IPalette p in palettes.Palettes) {
-                dig.Palettes.Add(p);
+            return dig;
+        }
+
+        private static byte[][] ReadCompressedBlocks(DataReader reader)
+        {
+            long basePosition = reader.Stream.Position;
+            int count = reader.ReadInt32();
+            byte[][] compressedBlocks = new byte[count][];
+
+            for (int i = 0; i < count; i++) {
+                ushort encodedOffset = reader.ReadUInt16();
+                ushort length = reader.ReadUInt16();
+
+                long blockPosition = basePosition + (encodedOffset * 4);
+                using (reader.Stream.EnterWithPosition(blockPosition)) {
+                    compressedBlocks[i] = reader.ReadBytes(length);
+                }
             }
 
-            return dig;
+            return compressedBlocks;
         }
     }
 }

--- a/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
+++ b/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
@@ -35,6 +35,28 @@ namespace JUS.Tool.Graphics.Converters
     /// </summary>
     public class Binary2Dig : IConverter<IBinary, Dig>
     {
+        private readonly bool forceSupportAlpha;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="Binary2Dig"/> class without
+        /// overwriting the support of alpha channels.
+        /// </summary>
+        public Binary2Dig()
+        {
+            forceSupportAlpha = false;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="Binary2Dig"/> class.
+        /// </summary>
+        /// <param name="forceSupportAlpha">
+        /// Value that specifies whether the palette color encoding follows the DSIG header value or uses ABGR1555.
+        /// </param>
+        public Binary2Dig(bool forceSupportAlpha)
+        {
+            this.forceSupportAlpha = forceSupportAlpha;
+        }
+
         /// <summary>
         /// Converts a <see cref="BinaryFormat"/> (file) to a <see cref="Dig"/>.
         /// </summary>
@@ -57,16 +79,21 @@ namespace JUS.Tool.Graphics.Converters
             var bpp = (DigBpp)(flags & 0x0F);
             var dataFormat = (DigDataFormat)(flags >> 4);
             byte paletteCount = reader.ReadByte();
-            byte unk07 = reader.ReadByte();
+            var colorFormat = (DigColorFormat)reader.ReadByte();
             ushort field08 = reader.ReadUInt16();
             ushort field0A = reader.ReadUInt16();
 
             // Palettes have always 16 colors per palette, but in 8bpp they are combined into a single big palette
             int colorsPerPalette = bpp == DigBpp.Bpp8 ? paletteCount * 16 : 16;
             int actualPaletteCount = bpp == DigBpp.Bpp8 ? 1 : paletteCount;
+            DigColorFormat actualColorFormat = forceSupportAlpha ? DigColorFormat.Abgr555 : colorFormat;
+            IColorEncoding colorEncoding = actualColorFormat switch {
+                DigColorFormat.Bgr555 => Bgr555Encoding.Instance,
+                DigColorFormat.Abgr555 => Abgr555Encoding.Instance,
+                _ => throw new FormatException($"Unknown color format: {colorFormat}"),
+            };
 
             // The format 4 (compressed block) seems to use the alpha bit
-            IColorEncoding colorEncoding = dataFormat is DigDataFormat.CompressedBlocks ? Abgr555Encoding.Instance : Bgr555Encoding.Instance;
             var palettes = new Collection<IPalette>();
             for (int i = 0; i < actualPaletteCount; i++) {
                 Rgb[] colors = colorEncoding.DecodeExactly(reader.Stream, colorsPerPalette);
@@ -122,7 +149,8 @@ namespace JUS.Tool.Graphics.Converters
                 Width = width,
                 Height = height,
                 OriginalSize = originalSize,
-                UnknownValue7 = unk07,
+                FormatColorEncoding = colorFormat,
+                ActualColorEncodingFormat = actualColorFormat,
                 Pixels = pixels,
                 Palettes = palettes,
                 UnknownBlockValue = unkBlockValue,

--- a/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
+++ b/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
@@ -70,10 +70,7 @@ namespace JUS.Tool.Graphics.Converters
             source.Stream.Position = 0;
 
             // Header
-            if (reader.ReadString(4) != Dig.Stamp) {
-                throw new FormatException("Invalid stamp");
-            }
-
+            FormatException.ThrowIfNotEqual(reader.ReadString(4), Dig.Stamp, "stamp");
             byte version = reader.ReadByte();
             byte flags = reader.ReadByte();
             var bpp = (DigBpp)(flags & 0x0F);
@@ -83,42 +80,23 @@ namespace JUS.Tool.Graphics.Converters
             ushort field08 = reader.ReadUInt16();
             ushort field0A = reader.ReadUInt16();
 
-            // Palettes have always 16 colors per palette, but in 8bpp they are combined into a single big palette
-            int colorsPerPalette = bpp == DigBpp.Bpp8 ? paletteCount * 16 : 16;
-            int actualPaletteCount = bpp == DigBpp.Bpp8 ? 1 : paletteCount;
+            // Palette
+            // DSIG inside DSTX type 4 use ABGR555 no matter what the header says
             DigColorFormat actualColorFormat = forceSupportAlpha ? DigColorFormat.Abgr555 : colorFormat;
-            IColorEncoding colorEncoding = actualColorFormat switch {
-                DigColorFormat.Bgr555 => Bgr555Encoding.Instance,
-                DigColorFormat.Abgr555 => Abgr555Encoding.Instance,
-                _ => throw new FormatException($"Unknown color format: {colorFormat}"),
-            };
-
-            // The format 4 (compressed block) seems to use the alpha bit
-            var palettes = new Collection<IPalette>();
-            for (int i = 0; i < actualPaletteCount; i++) {
-                Rgb[] colors = colorEncoding.DecodeExactly(reader.Stream, colorsPerPalette);
-                palettes.Add(new Palette(colors));
-            }
+            Collection<IPalette> palettes = ReadPalettes(reader, paletteCount, actualColorFormat, bpp);
 
             uint unkBlockValue = 0;
             if (version != 1 && dataFormat is DigDataFormat.CompressedBlocks) {
                 unkBlockValue = reader.ReadUInt32();
             }
 
-            Stream pixelData = reader.Stream.Slice(reader.Stream.Position);
-            if (dataFormat is DigDataFormat.CompressedImage) {
-                pixelData = new LzssDecoder().Convert(pixelData);
-            }
+            (IndexedPixel[] pixels, DigBlockInfo[] blocks) = ReadImageData(source.Stream, bpp, dataFormat);
 
-            long pixelCount = bpp == DigBpp.Bpp4 ? pixelData.Length * 2 : pixelData.Length;
-
-            // In the case of compressed blocks, there isn't the concept of width.
-            // We generate an always valid one.
+            // In the case of compressed blocks, there isn't the concept of width. We generate an always valid one.
             int width, height;
             if (dataFormat == DigDataFormat.CompressedBlocks) {
-                // FUTURE: recalculate by pixel count after decompressing the blocks.
                 width = 8;
-                height = (int)(pixelCount / width);
+                height = pixels.Length / width;
             } else {
                 width = field08;
                 height = field0A;
@@ -128,18 +106,13 @@ namespace JUS.Tool.Graphics.Converters
             // These images do not really have a size, as they have segments to reconstruct a different image.
             // We calculate a valid size for them based on a minimal width (tile width).
             var originalSize = new Size(width, height);
-            if (dataFormat != DigDataFormat.CompressedBlocks && (width * height) != pixelCount) {
+            if (dataFormat != DigDataFormat.CompressedBlocks && (width * height) != pixels.Length) {
                 width = 8;
-                height = (int)(pixelCount / width);
+                height = pixels.Length / width;
             }
 
-            byte[][] compressedSegments = [];
-            IndexedPixel[] pixels = [];
-            if (dataFormat is DigDataFormat.CompressedBlocks) {
-                compressedSegments = ReadCompressedBlocks(reader);
-            } else {
-                pixelData.Position = 0;
-                pixels = ReadPixels(pixelData, width, height, bpp, dataFormat);
+            if (dataFormat is DigDataFormat.Tiled) {
+                pixels = new TileSwizzling<IndexedPixel>(width).Unswizzle(pixels);
             }
 
             var dig = new Dig {
@@ -154,34 +127,74 @@ namespace JUS.Tool.Graphics.Converters
                 Pixels = pixels,
                 Palettes = palettes,
                 UnknownBlockValue = unkBlockValue,
-                CompressedSegments = compressedSegments,
+                BlocksInfo = blocks,
             };
             return dig;
         }
 
-        private static IndexedPixel[] ReadPixels(Stream stream, int width, int height, DigBpp bpp, DigDataFormat format)
+        private static Collection<IPalette> ReadPalettes(DataReader reader, int paletteCount, DigColorFormat colorFormat, DigBpp bpp)
         {
-            if (width == 0 || height == 0) {
+            // Palettes have always 16 colors per palette, but in 8bpp they are combined into a single big palette
+            int colorsPerPalette = bpp == DigBpp.Bpp8 ? paletteCount * 16 : 16;
+            int actualPaletteCount = bpp == DigBpp.Bpp8 ? 1 : paletteCount;
+            IColorEncoding colorEncoding = colorFormat switch {
+                DigColorFormat.Bgr555 => Bgr555Encoding.Instance,
+                DigColorFormat.Abgr555 => Abgr555Encoding.Instance,
+                _ => throw new FormatException($"Unknown color format: {colorFormat}"),
+            };
+
+            var palettes = new Collection<IPalette>();
+            for (int i = 0; i < actualPaletteCount; i++) {
+                Rgb[] colors = colorEncoding.DecodeExactly(reader.Stream, colorsPerPalette);
+                palettes.Add(new Palette(colors));
+            }
+
+            return palettes;
+        }
+
+        private static (IndexedPixel[], DigBlockInfo[]) ReadImageData(Stream stream, DigBpp bpp, DigDataFormat format)
+        {
+            if (format is DigDataFormat.CompressedImage) {
+                // Decompress full block, and read as lineal.
+                using Stream compressed = stream.Slice(stream.Position);
+                using Stream decompressed = new LzssDecoder().Convert(compressed);
+                decompressed.Position = 0;
+                return ReadImageData(decompressed, bpp, DigDataFormat.Linear);
+            }
+
+            if (format is DigDataFormat.CompressedBlocks) {
+                // Read each block, decompress them, and read as lineal.
+                byte[][] compressedSegments = ReadCompressedBlocks(stream);
+
+                List<IndexedPixel> mergedPixels = [];
+                List<DigBlockInfo> blocks = [];
+                for (int i = 0; i < compressedSegments.Length; i++) {
+                    using var blockData = new MemoryStream(compressedSegments[i]);
+                    (IndexedPixel[] blockPixels, _) = ReadImageData(blockData, bpp, DigDataFormat.CompressedImage);
+                    blocks.Add(new DigBlockInfo(i, mergedPixels.Count, blockPixels.Length));
+                    mergedPixels.AddRange(blockPixels);
+                }
+
+                return (mergedPixels.ToArray(), blocks.ToArray());
+            }
+
+            IndexedPixel[] pixels = ReadPixels(stream, bpp);
+            return (pixels, []);
+        }
+
+        private static IndexedPixel[] ReadPixels(Stream stream, DigBpp bpp)
+        {
+            if (stream.EndOfStream) {
                 return [];
             }
 
-            IIndexedPixelEncoding pixelEncoding = bpp switch {
-                DigBpp.Bpp4 => Indexed4BppEncoding.Instance,
-                DigBpp.Bpp8 => Indexed8BppEncoding.Instance,
-                _ => throw new FormatException($"Unsupported BPP {bpp}"),
-            };
-
-            IndexedPixel[] pixels = pixelEncoding.DecodeExactly(stream, width * height);
-
-            if (format is DigDataFormat.Tiled) {
-                return new TileSwizzling<IndexedPixel>(width).Unswizzle(pixels);
-            }
-
-            return pixels;
+            byte[] data = stream.ReadBytes((int)(stream.Length - stream.Position));
+            return bpp.GetPixelEncoding().Decode(data);
         }
 
-        private static byte[][] ReadCompressedBlocks(DataReader reader)
+        private static byte[][] ReadCompressedBlocks(Stream stream)
         {
+            var reader = new DataReader(stream);
             long basePosition = reader.Stream.Position;
             int count = reader.ReadInt32();
             byte[][] compressedBlocks = new byte[count][];

--- a/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
+++ b/src/JUS.Tool/Graphics/Converters/Binary2Dig.cs
@@ -21,6 +21,7 @@
 using System.Collections.ObjectModel;
 using System.Drawing;
 using JUS.Tool.Framework;
+using SceneGate.Ekona.Compression;
 using Texim.Colors;
 using Texim.Palettes;
 using Texim.Pixels;
@@ -61,52 +62,15 @@ namespace JUS.Tool.Graphics.Converters
             ushort field0A = reader.ReadUInt16();
 
             // Palettes have always 16 colors per palette, but in 8bpp they are combined into a single big palette
-            uint pixelsStart = (uint)((paletteCount * 0x20) + 0xC);
-            int pixelLength = (int)(source.Stream.Length - pixelsStart);
-            int pixelCount = bpp == DigBpp.Bpp4 ? pixelLength * 2 : pixelLength;
-
-            IIndexedPixelEncoding pixelEncoding;
-            int colorsPerPalette;
-            int actualPaletteCount;
-            switch (bpp) {
-                case DigBpp.Bpp4:
-                    pixelEncoding = Indexed4BppEncoding.Instance;
-                    colorsPerPalette = 16;
-                    actualPaletteCount = paletteCount;
-                    break;
-                case DigBpp.Bpp8:
-                    pixelEncoding = Indexed8BppEncoding.Instance;
-                    colorsPerPalette = paletteCount * 16;
-                    actualPaletteCount = 1;
-                    break;
-                default:
-                    throw new FormatException($"Invalid bpp: {bpp}");
-            }
-
-            // In the case of compressed blocks, there isn't the concept of width.
-            // We generate an always valid one.
-            int width, height;
-            if (dataFormat == DigDataFormat.CompressedBlocks) {
-                // FUTURE: recalculate by pixel count after decompressing the blocks.
-                width = 8;
-                height = pixelCount / width;
-            } else {
-                width = field08;
-                height = field0A;
-            }
-
-            // DSIG inside DTX may have a size larger than the amount of pixels present.
-            // Probably this was the size before DSTX segmentation and compression (or the grid size?).
-            var originalSize = new Size(width, height);
-            if (dataFormat != DigDataFormat.CompressedBlocks && (width * height) > pixelCount) {
-                width = 8;
-                height = pixelCount / width;
-            }
+            int colorsPerPalette = bpp == DigBpp.Bpp8 ? paletteCount * 16 : 16;
+            int actualPaletteCount = bpp == DigBpp.Bpp8 ? 1 : paletteCount;
 
             // The format 4 (compressed block) seems to use the alpha bit
+            IColorEncoding colorEncoding = dataFormat is DigDataFormat.CompressedBlocks ? Abgr555Encoding.Instance : Bgr555Encoding.Instance;
             var palettes = new Collection<IPalette>();
             for (int i = 0; i < actualPaletteCount; i++) {
-                palettes.Add(new Palette(reader.ReadColors<Abgr555Encoding>(colorsPerPalette)));
+                Rgb[] colors = colorEncoding.DecodeExactly(reader.Stream, colorsPerPalette);
+                palettes.Add(new Palette(colors));
             }
 
             uint unkBlockValue = 0;
@@ -114,26 +78,41 @@ namespace JUS.Tool.Graphics.Converters
                 unkBlockValue = reader.ReadUInt32();
             }
 
+            Stream pixelData = reader.Stream.Slice(reader.Stream.Position);
+            if (dataFormat is DigDataFormat.CompressedImage) {
+                pixelData = new LzssDecoder().Convert(pixelData);
+            }
+
+            long pixelCount = bpp == DigBpp.Bpp4 ? pixelData.Length * 2 : pixelData.Length;
+
+            // In the case of compressed blocks, there isn't the concept of width.
+            // We generate an always valid one.
+            int width, height;
+            if (dataFormat == DigDataFormat.CompressedBlocks) {
+                // FUTURE: recalculate by pixel count after decompressing the blocks.
+                width = 8;
+                height = (int)(pixelCount / width);
+            } else {
+                width = field08;
+                height = field0A;
+            }
+
+            // DSIG inside DTX may have width and height values that doesn't represent the amount of pixels.
+            // These images do not really have a size, as they have segments to reconstruct a different image.
+            // We calculate a valid size for them based on a minimal width (tile width).
+            var originalSize = new Size(width, height);
+            if (dataFormat != DigDataFormat.CompressedBlocks && (width * height) != pixelCount) {
+                width = 8;
+                height = (int)(pixelCount / width);
+            }
+
             byte[][] compressedSegments = [];
             IndexedPixel[] pixels = [];
-            switch (dataFormat) {
-                case DigDataFormat.Linear:
-                case DigDataFormat.Unknown5:
-                    pixels = pixelEncoding.DecodeExactly(source.Stream, width * height);
-                    break;
-
-                case DigDataFormat.Tiled:
-                    pixels = pixelEncoding.DecodeExactly(source.Stream, width * height);
-                    pixels = new TileSwizzling<IndexedPixel>(width).Unswizzle(pixels);
-                    break;
-
-                case DigDataFormat.CompressedBlocks:
-                    compressedSegments = ReadCompressedBlocks(reader);
-                    break;
-
-                case DigDataFormat.Unknown3:
-                default:
-                    throw new FormatException($"Invalid data format: {dataFormat}");
+            if (dataFormat is DigDataFormat.CompressedBlocks) {
+                compressedSegments = ReadCompressedBlocks(reader);
+            } else {
+                pixelData.Position = 0;
+                pixels = ReadPixels(pixelData, width, height, bpp, dataFormat);
             }
 
             var dig = new Dig {
@@ -150,6 +129,27 @@ namespace JUS.Tool.Graphics.Converters
                 CompressedSegments = compressedSegments,
             };
             return dig;
+        }
+
+        private static IndexedPixel[] ReadPixels(Stream stream, int width, int height, DigBpp bpp, DigDataFormat format)
+        {
+            if (width == 0 || height == 0) {
+                return [];
+            }
+
+            IIndexedPixelEncoding pixelEncoding = bpp switch {
+                DigBpp.Bpp4 => Indexed4BppEncoding.Instance,
+                DigBpp.Bpp8 => Indexed8BppEncoding.Instance,
+                _ => throw new FormatException($"Unsupported BPP {bpp}"),
+            };
+
+            IndexedPixel[] pixels = pixelEncoding.DecodeExactly(stream, width * height);
+
+            if (format is DigDataFormat.Tiled) {
+                return new TileSwizzling<IndexedPixel>(width).Unswizzle(pixels);
+            }
+
+            return pixels;
         }
 
         private static byte[][] ReadCompressedBlocks(DataReader reader)

--- a/src/JUS.Tool/Graphics/Converters/BinaryToDtx3.cs
+++ b/src/JUS.Tool/Graphics/Converters/BinaryToDtx3.cs
@@ -57,20 +57,20 @@ namespace JUS.Tool.Graphics.Converters
             for (int i = 0; i < numSprites; i++) {
                 Sprite sprite = ReadSprite(reader);
 
-                switch (image.Swizzling) {
-                    case DigSwizzling.Tiled:
+                switch (image.DataFormat) {
+                    case DigDataFormat.Tiled:
                         for (int j = 0; j < sprite.Segments.Count; j++) {
                             sprite.Segments[j].Layer = sprite.Segments.Count - j;
                         }
 
                         sprites.Root.Add(new Node($"sp_{i:00}", sprite));
                         break;
-                    case DigSwizzling.Linear:
+                    case DigDataFormat.Linear:
                         sprites.Root.Add(new Node($"tx_{i:00}", CreateTexture(sprite, image)));
                         spriteCollection.Add(sprite);
                         break;
                     default:
-                        throw new FormatException("Invalid swizzling");
+                        throw new FormatException("Invalid data format");
                 }
             }
 

--- a/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Drawing.Imaging;
+﻿using JUS.Tool.Framework;
 using Texim.Colors;
 using Texim.Palettes;
 using Texim.Pixels;
@@ -9,53 +8,103 @@ using Yarhl.IO;
 namespace JUS.Tool.Graphics.Converters
 {
     /// <summary>
-    /// Converts between BinaryFile and a <see cref="Dig"/> Node.
+    /// Converts a <see cref="Dig"/> image into its binary format.
     /// </summary>
     public class Dig2Binary :
     IConverter<Dig, BinaryFormat>
     {
         /// <summary>
-        /// Converts a Dig Node to a BinaryFormat Node.
+        /// Converts a dig to a binary format.
         /// </summary>
-        /// <param name="dig">Dig Node.</param>
-        /// <returns>BinaryFormat Node.</returns>
+        /// <param name="dig">Dig format.</param>
+        /// <returns>Binary format from memory.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="dig"/> is <c>null</c>.</exception>
         public BinaryFormat Convert(Dig dig)
         {
-            if (dig == null) {
-                throw new ArgumentNullException(nameof(dig));
-            }
+            ArgumentNullException.ThrowIfNull(dig);
 
             var binary = new BinaryFormat();
-
             var writer = new DataWriter(binary.Stream);
 
             writer.Write(Dig.STAMP, false);
-            writer.Write(dig.Unknown);
-            writer.Write(dig.ImageFormat);
-            writer.Write(dig.NumPaletteLines);
-            writer.Write((ushort)dig.Width);
-            writer.Write((ushort)dig.Height);
+            writer.Write(dig.Version);
 
-            foreach (IPalette c in dig.Palettes) {
-                writer.Write<Bgr555Encoding>(c.Colors);
+            int flags = ((int)dig.DataFormat << 4) | (int)dig.Bpp;
+            writer.Write((byte)flags);
+
+            int formatPaletteCount = dig.Bpp == DigBpp.Bpp4
+                ? dig.Palettes.Count
+                : (int)Math.Ceiling(dig.Palettes[0].Colors.Count / 16.0);
+            writer.Write((byte)formatPaletteCount);
+
+            writer.Write((byte)dig.Metadata.Length);
+
+            if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
+                writer.WriteTimes(0x00, 4); // placeholder
+            } else {
+                writer.Write((ushort)dig.OriginalSize.Width);
+                writer.Write((ushort)dig.OriginalSize.Height);
             }
 
+            foreach (IPalette c in dig.Palettes) {
+                writer.Write<Abgr555Encoding>(c.Colors);
+            }
+
+            writer.Write(dig.Metadata);
+
+            if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
+                WriteCompressedBlocks(writer, dig);
+            } else {
+                WriteIndexedPixels(writer, dig);
+            }
+
+            return binary;
+        }
+
+        private static void WriteIndexedPixels(DataWriter writer, Dig dig)
+        {
             IIndexedPixelEncoding encoder = dig.Bpp switch {
                 DigBpp.Bpp4 => Indexed4BppEncoding.Instance,
                 DigBpp.Bpp8 => Indexed8BppEncoding.Instance,
                 _ => throw new FormatException("Invalid bpp"),
             };
 
-            writer.Stream.Position = dig.PixelsStart;
-            IndexedPixel[] pixels = dig.Swizzling switch {
-                DigSwizzling.Linear => dig.Pixels,
-                DigSwizzling.Tiled => new TileSwizzling<IndexedPixel>(dig.Width).Swizzle(dig.Pixels),
-                _ => throw new FormatException("Invalid swizzling"),
+            IndexedPixel[] pixels = dig.DataFormat switch {
+                DigDataFormat.Linear => dig.Pixels,
+                DigDataFormat.Unknown5 => dig.Pixels,
+                DigDataFormat.Tiled => new TileSwizzling<IndexedPixel>(dig.Width).Swizzle(dig.Pixels),
+                _ => throw new FormatException("Invalid format"),
             };
             writer.Write(encoder.Encode(pixels));
+        }
 
-            return binary;
+        private static void WriteCompressedBlocks(DataWriter writer, Dig dig)
+        {
+            long basePosition = writer.Stream.Position;
+            writer.Write(dig.CompressedSegments.Length);
+
+            // prefill table
+            writer.WriteTimes(0x00, 4 * dig.CompressedSegments.Length);
+            writer.Stream.Position = basePosition + 4;
+
+            // Write table entry and block
+            foreach (byte[] block in dig.CompressedSegments) {
+                ushort encodedOffset = (ushort)((writer.Stream.Length - basePosition) / 4);
+                writer.Write(encodedOffset);
+                writer.Write((ushort)block.Length);
+
+                using (writer.Stream.EnterWithPosition(0, SeekOrigin.End)) {
+                    writer.Write(block);
+                    writer.WritePadding(0x00, 4);
+                }
+            }
+
+            int infoLength = 4 + (4 * dig.CompressedSegments.Length);
+            int dataLength = (int)(writer.Stream.Length - basePosition + dig.Metadata.Length);
+
+            writer.Stream.Position = 0x08;
+            writer.Write((ushort)(infoLength / 4));
+            writer.Write((ushort)(dataLength / 4));
         }
     }
 }

--- a/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
@@ -71,9 +71,9 @@ namespace JUS.Tool.Graphics.Converters
                 _ => throw new FormatException("Invalid bpp"),
             };
 
+            // TODO: compress for format compressed image
             IndexedPixel[] pixels = dig.DataFormat switch {
-                DigDataFormat.Linear => dig.Pixels,
-                DigDataFormat.Unknown5 => dig.Pixels,
+                DigDataFormat.Linear or DigDataFormat.CompressedBlocks => dig.Pixels,
                 DigDataFormat.Tiled => new TileSwizzling<IndexedPixel>(dig.Width).Swizzle(dig.Pixels),
                 _ => throw new FormatException("Invalid format"),
             };

--- a/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
@@ -1,4 +1,5 @@
 ﻿using JUS.Tool.Framework;
+using SceneGate.Ekona.Compression;
 using Texim.Colors;
 using Texim.Palettes;
 using Texim.Pixels;
@@ -36,8 +37,7 @@ namespace JUS.Tool.Graphics.Converters
                 ? dig.Palettes.Count
                 : (int)Math.Ceiling(dig.Palettes[0].Colors.Count / 16.0);
             writer.Write((byte)formatPaletteCount);
-
-            writer.Write(dig.UnknownValue7);
+            writer.Write((byte)dig.FormatColorEncoding);
 
             if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
                 writer.WriteTimes(0x00, 4); // placeholder
@@ -46,7 +46,11 @@ namespace JUS.Tool.Graphics.Converters
                 writer.Write((ushort)dig.OriginalSize.Height);
             }
 
-            IColorEncoding colorEncoding = dig.DataFormat is DigDataFormat.CompressedBlocks ? Abgr555Encoding.Instance : Bgr555Encoding.Instance;
+            IColorEncoding colorEncoding = dig.ActualColorEncodingFormat switch {
+                DigColorFormat.Bgr555 => Bgr555Encoding.Instance,
+                DigColorFormat.Abgr555 => Abgr555Encoding.Instance,
+                _ => throw new FormatException($"Unknown color encoding: {dig.ActualColorEncodingFormat}"),
+            };
             foreach (IPalette c in dig.Palettes) {
                 writer.Write(colorEncoding.Encode(c.Colors));
             }
@@ -74,11 +78,19 @@ namespace JUS.Tool.Graphics.Converters
 
             // TODO: compress for format compressed image
             IndexedPixel[] pixels = dig.DataFormat switch {
-                DigDataFormat.Linear or DigDataFormat.CompressedBlocks => dig.Pixels,
+                DigDataFormat.Linear or DigDataFormat.CompressedImage => dig.Pixels,
                 DigDataFormat.Tiled => new TileSwizzling<IndexedPixel>(dig.Width).Swizzle(dig.Pixels),
                 _ => throw new FormatException("Invalid format"),
             };
-            writer.Write(encoder.Encode(pixels));
+            byte[] encodedPixels = encoder.Encode(pixels);
+
+            if (dig.DataFormat is DigDataFormat.CompressedImage) {
+                using var inputCompression = new MemoryStream(encodedPixels);
+                using Stream outputCompression = new LzssEncoder().Convert(inputCompression);
+                outputCompression.WriteTo(writer.Stream);
+            } else {
+                writer.Write(encodedPixels);
+            }
         }
 
         private static void WriteCompressedBlocks(DataWriter writer, Dig dig)

--- a/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
@@ -40,7 +40,7 @@ namespace JUS.Tool.Graphics.Converters
             writer.Write((byte)dig.FormatColorEncoding);
 
             if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
-                writer.WriteTimes(0x00, 4); // placeholder
+                writer.WriteTimes(0x00, 4); // placeholder for block infos
             } else {
                 writer.Write((ushort)dig.OriginalSize.Width);
                 writer.Write((ushort)dig.OriginalSize.Height);
@@ -62,59 +62,58 @@ namespace JUS.Tool.Graphics.Converters
 
                 WriteCompressedBlocks(writer, dig);
             } else {
-                WriteIndexedPixels(writer, dig);
+                WriteIndexedPixels(writer.Stream, dig);
             }
 
             return binary;
         }
 
-        private static void WriteIndexedPixels(DataWriter writer, Dig dig)
+        private static void WriteIndexedPixels(Stream stream, Dig dig)
         {
-            IIndexedPixelEncoding encoder = dig.Bpp switch {
-                DigBpp.Bpp4 => Indexed4BppEncoding.Instance,
-                DigBpp.Bpp8 => Indexed8BppEncoding.Instance,
-                _ => throw new FormatException("Invalid bpp"),
-            };
-
-            // TODO: compress for format compressed image
             IndexedPixel[] pixels = dig.DataFormat switch {
                 DigDataFormat.Linear or DigDataFormat.CompressedImage => dig.Pixels,
                 DigDataFormat.Tiled => new TileSwizzling<IndexedPixel>(dig.Width).Swizzle(dig.Pixels),
                 _ => throw new FormatException("Invalid format"),
             };
-            byte[] encodedPixels = encoder.Encode(pixels);
+            byte[] encodedPixels = dig.Bpp.GetPixelEncoding().Encode(pixels);
 
             if (dig.DataFormat is DigDataFormat.CompressedImage) {
                 using var inputCompression = new MemoryStream(encodedPixels);
                 using Stream outputCompression = new LzssEncoder().Convert(inputCompression);
-                outputCompression.WriteTo(writer.Stream);
+                outputCompression.WriteTo(stream);
             } else {
-                writer.Write(encodedPixels);
+                stream.Write(encodedPixels);
             }
         }
 
         private static void WriteCompressedBlocks(DataWriter writer, Dig dig)
         {
             long basePosition = writer.Stream.Position;
-            writer.Write(dig.CompressedSegments.Length);
+            writer.Write(dig.BlocksInfo.Length);
 
             // prefill table
-            writer.WriteTimes(0x00, 4 * dig.CompressedSegments.Length);
+            writer.WriteTimes(0x00, 4 * dig.BlocksInfo.Length);
             writer.Stream.Position = basePosition + 4;
 
             // Write table entry and block
-            foreach (byte[] block in dig.CompressedSegments) {
+            foreach (DigBlockInfo block in dig.BlocksInfo) {
+                // Compress
+                ReadOnlySpan<IndexedPixel> blockPixels = dig.Pixels.AsSpan(block.PixelStart, block.PixelCount);
+                byte[] encodedPixels = dig.Bpp.GetPixelEncoding().Encode(blockPixels);
+                using var inputCompression = new MemoryStream(encodedPixels);
+                using Stream outputCompression = new LzssEncoder().Convert(inputCompression);
+
                 ushort encodedOffset = (ushort)((writer.Stream.Length - basePosition) / 4);
                 writer.Write(encodedOffset);
-                writer.Write((ushort)block.Length);
+                writer.Write((ushort)outputCompression.Length);
 
                 using (writer.Stream.EnterWithPosition(0, SeekOrigin.End)) {
-                    writer.Write(block);
+                    outputCompression.WriteTo(writer.Stream);
                     writer.WritePadding(0x00, 4);
                 }
             }
 
-            int infoLength = 4 + (4 * dig.CompressedSegments.Length);
+            int infoLength = 4 + (4 * dig.BlocksInfo.Length);
             int dataLength = (int)(writer.Stream.Length - basePosition + 4);
 
             writer.Stream.Position = 0x08;

--- a/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
@@ -46,8 +46,9 @@ namespace JUS.Tool.Graphics.Converters
                 writer.Write((ushort)dig.OriginalSize.Height);
             }
 
+            IColorEncoding colorEncoding = dig.DataFormat is DigDataFormat.CompressedBlocks ? Abgr555Encoding.Instance : Bgr555Encoding.Instance;
             foreach (IPalette c in dig.Palettes) {
-                writer.Write<Abgr555Encoding>(c.Colors);
+                writer.Write(colorEncoding.Encode(c.Colors));
             }
 
             if (dig.DataFormat is DigDataFormat.CompressedBlocks) {

--- a/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
@@ -26,7 +26,7 @@ namespace JUS.Tool.Graphics.Converters
             var binary = new BinaryFormat();
             var writer = new DataWriter(binary.Stream);
 
-            writer.Write(Dig.STAMP, false);
+            writer.Write(Dig.Stamp, false);
             writer.Write(dig.Version);
 
             int flags = ((int)dig.DataFormat << 4) | (int)dig.Bpp;
@@ -37,7 +37,7 @@ namespace JUS.Tool.Graphics.Converters
                 : (int)Math.Ceiling(dig.Palettes[0].Colors.Count / 16.0);
             writer.Write((byte)formatPaletteCount);
 
-            writer.Write((byte)dig.Metadata.Length);
+            writer.Write(dig.UnknownValue7);
 
             if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
                 writer.WriteTimes(0x00, 4); // placeholder
@@ -50,9 +50,11 @@ namespace JUS.Tool.Graphics.Converters
                 writer.Write<Abgr555Encoding>(c.Colors);
             }
 
-            writer.Write(dig.Metadata);
-
             if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
+                if (dig.Version != 1) {
+                    writer.Write(dig.UnknownBlockValue);
+                }
+
                 WriteCompressedBlocks(writer, dig);
             } else {
                 WriteIndexedPixels(writer, dig);
@@ -100,7 +102,7 @@ namespace JUS.Tool.Graphics.Converters
             }
 
             int infoLength = 4 + (4 * dig.CompressedSegments.Length);
-            int dataLength = (int)(writer.Stream.Length - basePosition + dig.Metadata.Length);
+            int dataLength = (int)(writer.Stream.Length - basePosition + 4);
 
             writer.Stream.Position = 0x08;
             writer.Write((ushort)(infoLength / 4));

--- a/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dig2Binary.cs
@@ -1,5 +1,4 @@
-﻿using JUS.Tool.Framework;
-using SceneGate.Ekona.Compression;
+﻿using SceneGate.Ekona.Compression;
 using Texim.Colors;
 using Texim.Palettes;
 using Texim.Pixels;
@@ -27,33 +26,8 @@ namespace JUS.Tool.Graphics.Converters
             var binary = new BinaryFormat();
             var writer = new DataWriter(binary.Stream);
 
-            writer.Write(Dig.Stamp, false);
-            writer.Write(dig.Version);
-
-            int flags = ((int)dig.DataFormat << 4) | (int)dig.Bpp;
-            writer.Write((byte)flags);
-
-            int formatPaletteCount = dig.Bpp == DigBpp.Bpp4
-                ? dig.Palettes.Count
-                : (int)Math.Ceiling(dig.Palettes[0].Colors.Count / 16.0);
-            writer.Write((byte)formatPaletteCount);
-            writer.Write((byte)dig.FormatColorEncoding);
-
-            if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
-                writer.WriteTimes(0x00, 4); // placeholder for block infos
-            } else {
-                writer.Write((ushort)dig.OriginalSize.Width);
-                writer.Write((ushort)dig.OriginalSize.Height);
-            }
-
-            IColorEncoding colorEncoding = dig.ActualColorEncodingFormat switch {
-                DigColorFormat.Bgr555 => Bgr555Encoding.Instance,
-                DigColorFormat.Abgr555 => Abgr555Encoding.Instance,
-                _ => throw new FormatException($"Unknown color encoding: {dig.ActualColorEncodingFormat}"),
-            };
-            foreach (IPalette c in dig.Palettes) {
-                writer.Write(colorEncoding.Encode(c.Colors));
-            }
+            WriteHeader(writer, dig);
+            WritePalettes(writer, dig);
 
             if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
                 if (dig.Version != 1) {
@@ -68,13 +42,46 @@ namespace JUS.Tool.Graphics.Converters
             return binary;
         }
 
+        private static void WriteHeader(DataWriter writer, Dig dig)
+        {
+            writer.Write(Dig.Stamp, false);
+            writer.Write(dig.Version);
+
+            int flags = ((int)dig.DataFormat << 4) | (int)dig.Bpp;
+            writer.Write((byte)flags);
+
+            int formatPaletteCount = dig.Bpp == DigBpp.Bpp4
+                ? dig.Palettes.Count
+                : (int)Math.Ceiling(dig.Palettes[0].Colors.Count / 16.0);
+            writer.Write((byte)formatPaletteCount);
+            writer.Write((byte)dig.FormatColorEncoding);
+
+            if (dig.DataFormat is DigDataFormat.CompressedBlocks) {
+                writer.WriteTimes(0x00, 4); // placeholder for block infos
+            } else if (dig.HasValidSize) {
+                writer.Write((ushort)dig.Width);
+                writer.Write((ushort)dig.Height);
+            } else {
+                // Ignore current image size, and write what it was originally
+                writer.Write((ushort)dig.OriginalSize.Width);
+                writer.Write((ushort)dig.OriginalSize.Height);
+            }
+        }
+
+        private static void WritePalettes(DataWriter writer, Dig dig)
+        {
+            IColorEncoding colorEncoding = dig.ActualColorEncodingFormat.GetColorEncoding();
+            foreach (IPalette c in dig.Palettes) {
+                byte[] encodedColors = colorEncoding.Encode(c.Colors);
+                writer.Write(encodedColors);
+            }
+        }
+
         private static void WriteIndexedPixels(Stream stream, Dig dig)
         {
-            IndexedPixel[] pixels = dig.DataFormat switch {
-                DigDataFormat.Linear or DigDataFormat.CompressedImage => dig.Pixels,
-                DigDataFormat.Tiled => new TileSwizzling<IndexedPixel>(dig.Width).Swizzle(dig.Pixels),
-                _ => throw new FormatException("Invalid format"),
-            };
+            IndexedPixel[] pixels = dig.DataFormat is DigDataFormat.Tiled
+                ? new TileSwizzling<IndexedPixel>(dig.Width).Swizzle(dig.Pixels)
+                : dig.Pixels;
             byte[] encodedPixels = dig.Bpp.GetPixelEncoding().Encode(pixels);
 
             if (dig.DataFormat is DigDataFormat.CompressedImage) {
@@ -114,7 +121,10 @@ namespace JUS.Tool.Graphics.Converters
             }
 
             int infoLength = 4 + (4 * dig.BlocksInfo.Length);
-            int dataLength = (int)(writer.Stream.Length - basePosition + 4);
+            int dataLength = (int)(writer.Stream.Length - basePosition);
+            if (dig.Version != 1) {
+                dataLength += 4;
+            }
 
             writer.Stream.Position = 0x08;
             writer.Write((ushort)(infoLength / 4));

--- a/src/JUS.Tool/Graphics/Converters/Dtx2Bitmaps.cs
+++ b/src/JUS.Tool/Graphics/Converters/Dtx2Bitmaps.cs
@@ -17,8 +17,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-using JUS.Tool.Graphics.Converters;
-using Texim.Images;
 using Texim.Formats.ImageSharp.Images;
 using Texim.Sprites;
 using Yarhl.FileFormat;
@@ -57,8 +55,8 @@ namespace JUS.Tool.Graphics.Converters
 
             var bitmaps = new NodeContainerFormat();
 
-            switch (image.Swizzling) {
-                case DigSwizzling.Tiled:
+            switch (image.DataFormat) {
+                case DigDataFormat.Tiled:
                     foreach (Node nodeSprite in dtx3.Root.Children["sprites"].Children) {
                         // Cloning the node so we can transform it
                         bitmaps.Root.Add(new Node(nodeSprite.Name, nodeSprite.GetFormatAs<Sprite>())
@@ -67,7 +65,7 @@ namespace JUS.Tool.Graphics.Converters
                     }
 
                     break;
-                case DigSwizzling.Linear:
+                case DigDataFormat.Linear:
                     foreach (Node nodeTexture in dtx3.Root.Children["sprites"].Children) {
                         // Cloning the node so we can transform it
                         bitmaps.Root.Add(new Node(nodeTexture.Name, nodeTexture.GetFormatAs<Dig>())
@@ -76,7 +74,7 @@ namespace JUS.Tool.Graphics.Converters
 
                     break;
                 default:
-                    throw new FormatException("Invalid swizzling");
+                    throw new FormatException("Invalid data format");
             }
 
             return bitmaps;

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -134,7 +134,10 @@ namespace JUS.Tool.Graphics
             UnknownBlockValue = dig.UnknownBlockValue;
             BlocksInfo = dig.BlocksInfo.ToArray();
             Pixels = dig.Pixels.ToArray();
-            Palettes = new Collection<IPalette>(dig.Palettes);
+            Palettes = new Collection<IPalette>();
+            foreach (IPalette palette in dig.Palettes) {
+                Palettes.Add(new Palette(palette.Colors));
+            }
         }
 
         /// <summary>

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
+using JUS.Tool.Framework;
 using JUS.Tool.Utils;
+using Texim.Colors;
 using Texim.Images;
 using Texim.Palettes;
 using Texim.Pixels;
@@ -125,6 +127,7 @@ namespace JUS.Tool.Graphics
             DataFormat = dig.DataFormat;
             Width = dig.Width;
             Height = dig.Height;
+            HasValidSize = dig.HasValidSize;
             OriginalSize = dig.OriginalSize;
             FormatColorEncoding = dig.FormatColorEncoding;
             ActualColorEncodingFormat = dig.ActualColorEncodingFormat;
@@ -233,6 +236,11 @@ namespace JUS.Tool.Graphics
         /// Gets or sets the information about the blocks, if any.
         /// </summary>
         public DigBlockInfo[] BlocksInfo { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the format stores a width and height that matches the pixel count.
+        /// </summary>
+        public bool HasValidSize { get; set; }
 
         /// <summary>
         /// Gets or sets the original size in the binary format that doesn't match the pixel count.
@@ -376,6 +384,15 @@ namespace JUS.Tool.Graphics
                 DigBpp.Bpp4 => Indexed4BppEncoding.Instance,
                 DigBpp.Bpp8 => Indexed8BppEncoding.Instance,
                 _ => throw new FormatException($"Invalid bpp: {bpp}"),
+            };
+        }
+
+        extension(DigColorFormat format)
+        {
+            public IColorEncoding GetColorEncoding() => format switch {
+                DigColorFormat.Bgr555 => Bgr555Encoding.Instance,
+                DigColorFormat.Abgr555 => Abgr555Encoding.Instance,
+                _ => throw new FormatException($"Unknown color encoding: {format}"),
             };
         }
     }

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
 using JUS.Tool.Utils;
 using Texim.Images;
 using Texim.Palettes;
@@ -24,10 +26,15 @@ namespace JUS.Tool.Graphics
     }
 
     /// <summary>
-    /// Swizzling of a <see cref="Dig"/> image.
+    /// Format of the data of an <see cref="Dig"/> image.
     /// </summary>
-    public enum DigSwizzling
+    public enum DigDataFormat
     {
+        /// <summary>
+        /// Invalid image format.
+        /// </summary>
+        None = 0,
+
         /// <summary>
         /// Tiled swizzling.
         /// </summary>
@@ -37,6 +44,21 @@ namespace JUS.Tool.Graphics
         /// Linear swizzling.
         /// </summary>
         Linear = 2,
+
+        /// <summary>
+        /// Unknown format, not used on this game.
+        /// </summary>
+        Unknown3 = 3,
+
+        /// <summary>
+        /// Blocks of compressed data.
+        /// </summary>
+        CompressedBlocks = 4,
+
+        /// <summary>
+        /// Unknown format.
+        /// </summary>
+        Unknown5 = 5,
     }
 
     /// <summary>
@@ -64,6 +86,8 @@ namespace JUS.Tool.Graphics
         /// </summary>
         public Dig()
         {
+            Metadata = [];
+            CompressedSegments = [];
         }
 
         /// <summary>
@@ -73,26 +97,22 @@ namespace JUS.Tool.Graphics
         [SetsRequiredMembers]
         public Dig(Dig dig)
         {
-            Unknown = dig.Unknown;
-            ImageFormat = dig.ImageFormat;
-            NumPaletteLines = dig.NumPaletteLines;
+            Version = dig.Version;
+            Bpp = dig.Bpp;
+            DataFormat = dig.DataFormat;
             Width = dig.Width;
             Height = dig.Height;
-            Pixels = dig.Pixels;
-            PaletteStart = dig.PaletteStart;
-            PixelsStart = dig.PixelsStart;
-            Bpp = dig.Bpp;
-            Swizzling = dig.Swizzling;
-            foreach (IPalette p in dig.Palettes) {
-                Palettes.Add(p);
-            }
+            Metadata = dig.Metadata.ToArray();
+            CompressedSegments = dig.CompressedSegments.ToArray();
+            Pixels = dig.Pixels.ToArray();
+            Palettes = new Collection<IPalette>(dig.Palettes);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Dig"/> class cloning the indexed image.
         /// </summary>
         /// <param name="dig">Dig object to clone.</param>
-        /// <param name="image">IndexedImage object to clone.</param>
+        /// <param name="image">Indexed image object to clone.</param>
         [SetsRequiredMembers]
         public Dig(Dig dig, IIndexedImage image)
             : this(dig)
@@ -154,39 +174,35 @@ namespace JUS.Tool.Graphics
         }
 
         /// <summary>
-        /// Gets or sets the first byte of the format. Maybe the Type?.
+        /// Gets or sets the format version.
         /// </summary>
-        public byte Unknown { get; set; }
+        public byte Version { get; set; }
 
         /// <summary>
-        /// Gets or sets the ImageFormat.
-        /// </summary>
-        public byte ImageFormat { get; set; }
-
-        /// <summary>
-        /// Gets or sets the NumPaletteLines.
-        /// </summary>
-        public ushort NumPaletteLines { get; set; }
-
-        /// <summary>
-        /// Gets or sets the PaletteStart value.
-        /// </summary>
-        public uint PaletteStart { get; set; }
-
-        /// <summary>
-        /// Gets or sets the PixelsStart value.
-        /// </summary>
-        public uint PixelsStart { get; set; }
-
-        /// <summary>
-        /// Gets or sets the Bpp mode.
+        /// Gets or sets the bits per pixel (pixel encoding).
         /// </summary>
         public DigBpp Bpp { get; set; }
 
         /// <summary>
-        /// Gets or sets the Swizzling mode.
+        /// Gets or sets the format of the pixel data.
         /// </summary>
-        public DigSwizzling Swizzling { get; set; }
+        public DigDataFormat DataFormat { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unknown metadata from version 2, format compressed blocks.
+        /// </summary>
+        public byte[] Metadata { get; set; }
+
+        /// <summary>
+        /// Gets or sets the compressed image segments from compressed block format.
+        /// </summary>
+        public byte[][] CompressedSegments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the original size in the binary format that doesn't match the pixel count.
+        /// </summary>
+        /// <remarks>Probably the size before DSTX compression.</remarks>
+        public Size OriginalSize { get; set; }
 
         /// <summary>
         /// Paste a <see cref="Dig"/> subimage into this <see cref="Dig"/>.

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -78,6 +78,14 @@ namespace JUS.Tool.Graphics
     }
 
     /// <summary>
+    /// Information about a compressed DSIG type 4 block.
+    /// </summary>
+    /// <param name="Index">The block index.</param>
+    /// <param name="PixelStart">The index of the first pixel in the block.</param>
+    /// <param name="PixelCount">The number of pixels in the block.</param>
+    public sealed record DigBlockInfo(int Index, int PixelStart, int PixelCount);
+
+    /// <summary>
     /// Image format.
     /// </summary>
     public class Dig : IndexedPaletteImage
@@ -102,7 +110,7 @@ namespace JUS.Tool.Graphics
         /// </summary>
         public Dig()
         {
-            CompressedSegments = [];
+            BlocksInfo = [];
         }
 
         /// <summary>
@@ -121,7 +129,7 @@ namespace JUS.Tool.Graphics
             FormatColorEncoding = dig.FormatColorEncoding;
             ActualColorEncodingFormat = dig.ActualColorEncodingFormat;
             UnknownBlockValue = dig.UnknownBlockValue;
-            CompressedSegments = dig.CompressedSegments.ToArray();
+            BlocksInfo = dig.BlocksInfo.ToArray();
             Pixels = dig.Pixels.ToArray();
             Palettes = new Collection<IPalette>(dig.Palettes);
         }
@@ -222,9 +230,9 @@ namespace JUS.Tool.Graphics
         public uint UnknownBlockValue { get; set; }
 
         /// <summary>
-        /// Gets or sets the compressed image segments from compressed block format.
+        /// Gets or sets the information about the blocks, if any.
         /// </summary>
-        public byte[][] CompressedSegments { get; set; }
+        public DigBlockInfo[] BlocksInfo { get; set; }
 
         /// <summary>
         /// Gets or sets the original size in the binary format that doesn't match the pixel count.
@@ -357,6 +365,18 @@ namespace JUS.Tool.Graphics
         {
             for (int i = 0; i < Pixels.Length; i++)
                 Pixels[i] = new IndexedPixel(Pixels[i].ColorIndex, Pixels[i].Alpha, paletteIndex);
+        }
+    }
+
+    internal static class DigExtensions
+    {
+        extension(DigBpp bpp)
+        {
+            public IIndexedPixelEncoding GetPixelEncoding() => bpp switch {
+                DigBpp.Bpp4 => Indexed4BppEncoding.Instance,
+                DigBpp.Bpp8 => Indexed8BppEncoding.Instance,
+                _ => throw new FormatException($"Invalid bpp: {bpp}"),
+            };
         }
     }
 }

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -69,7 +69,7 @@ namespace JUS.Tool.Graphics
         /// <summary>
         /// The Magic ID of the file.
         /// </summary>
-        public const string STAMP = "DSIG";
+        public const string Stamp = "DSIG";
 
         /// <summary>
         /// 10 bits for the tile index.
@@ -86,7 +86,6 @@ namespace JUS.Tool.Graphics
         /// </summary>
         public Dig()
         {
-            Metadata = [];
             CompressedSegments = [];
         }
 
@@ -102,7 +101,8 @@ namespace JUS.Tool.Graphics
             DataFormat = dig.DataFormat;
             Width = dig.Width;
             Height = dig.Height;
-            Metadata = dig.Metadata.ToArray();
+            UnknownValue7 = dig.UnknownValue7;
+            UnknownBlockValue = dig.UnknownBlockValue;
             CompressedSegments = dig.CompressedSegments.ToArray();
             Pixels = dig.Pixels.ToArray();
             Palettes = new Collection<IPalette>(dig.Palettes);
@@ -189,9 +189,14 @@ namespace JUS.Tool.Graphics
         public DigDataFormat DataFormat { get; set; }
 
         /// <summary>
-        /// Gets or sets the unknown metadata from version 2, format compressed blocks.
+        /// Gets or sets the unknown value at position 7.
         /// </summary>
-        public byte[] Metadata { get; set; }
+        public byte UnknownValue7 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unknown value from compressed blocks in version 2.
+        /// </summary>
+        public uint UnknownBlockValue { get; set; }
 
         /// <summary>
         /// Gets or sets the compressed image segments from compressed block format.

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -101,6 +101,7 @@ namespace JUS.Tool.Graphics
             DataFormat = dig.DataFormat;
             Width = dig.Width;
             Height = dig.Height;
+            OriginalSize = dig.OriginalSize;
             UnknownValue7 = dig.UnknownValue7;
             UnknownBlockValue = dig.UnknownBlockValue;
             CompressedSegments = dig.CompressedSegments.ToArray();

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -62,6 +62,22 @@ namespace JUS.Tool.Graphics
     }
 
     /// <summary>
+    /// Format of the color encoding in DSIG palettes.
+    /// </summary>
+    public enum DigColorFormat
+    {
+        /// <summary>
+        /// BGR555 with no transparency.
+        /// </summary>
+        Bgr555 = 0,
+
+        /// <summary>
+        /// ABGR555 with one bit transparency.
+        /// </summary>
+        Abgr555 = 4,
+    }
+
+    /// <summary>
     /// Image format.
     /// </summary>
     public class Dig : IndexedPaletteImage
@@ -102,7 +118,8 @@ namespace JUS.Tool.Graphics
             Width = dig.Width;
             Height = dig.Height;
             OriginalSize = dig.OriginalSize;
-            UnknownValue7 = dig.UnknownValue7;
+            FormatColorEncoding = dig.FormatColorEncoding;
+            ActualColorEncodingFormat = dig.ActualColorEncodingFormat;
             UnknownBlockValue = dig.UnknownBlockValue;
             CompressedSegments = dig.CompressedSegments.ToArray();
             Pixels = dig.Pixels.ToArray();
@@ -190,9 +207,14 @@ namespace JUS.Tool.Graphics
         public DigDataFormat DataFormat { get; set; }
 
         /// <summary>
-        /// Gets or sets the unknown value at position 7.
+        /// Gets or sets the palette color encoding as specified in the DSIG binary format.
         /// </summary>
-        public byte UnknownValue7 { get; set; }
+        public DigColorFormat FormatColorEncoding { get; set; }
+
+        /// <summary>
+        /// Gets or sets the actual palette encoding format that DSTX may overwrite.
+        /// </summary>
+        public DigColorFormat ActualColorEncodingFormat { get; set; }
 
         /// <summary>
         /// Gets or sets the unknown value from compressed blocks in version 2.

--- a/src/JUS.Tool/Graphics/Dig.cs
+++ b/src/JUS.Tool/Graphics/Dig.cs
@@ -56,9 +56,9 @@ namespace JUS.Tool.Graphics
         CompressedBlocks = 4,
 
         /// <summary>
-        /// Unknown format.
+        /// One block of compressed data.
         /// </summary>
-        Unknown5 = 5,
+        CompressedImage = 5,
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

This PR implement the DSIG specification as much as we know it today. Major changes:

- Support color encoding field. Some DSIG use ABGR instead of BGR (color palettes with transparency).
- Support compressed formats: 4 and 5. The decompressed blocks from format 4 are merged into a single pixel array, but we keep the block information in a property.
- Store original image size when it's not valid, so it can be written identically later.
- Test with all the game DSIG (including inside DSTX)
  - Compressed formats test by deserializing again the generated binary file to compare pixels
- Split DSIG tests into different files (with different DSIG sources)

Also fix the discovery of converters for SceneGate UI. It was throwing an exception when we try to iteratively find the program info.

We have parallelize the tests of DSIG (more than 5000 test cases), so it runs faster. And improved the ALAR tests so they run also faster. The slowest part are LZSS (de)compression in ALAR and DSIG.

This PR should close #48 